### PR TITLE
OneWifi related hostap patch for 2.10 based hostap.

### DIFF
--- a/0001-OneWifi-related-hostap-patch-for-2.10-based-hostap.patch
+++ b/0001-OneWifi-related-hostap-patch-for-2.10-based-hostap.patch
@@ -1,0 +1,6517 @@
+From d217385ac30f0f2ba8d60862ec5e2e333541015f Mon Sep 17 00:00:00 2001
+From: Amarnath Hullur Subramanyam <amarnath_hullursubramanyam@comcast.com>
+Date: Tue, 29 Oct 2024 15:17:45 -0700
+Subject: [PATCH] OneWifi related hostap patch for 2.10 based hostap.
+
+This patch consolidates all the required hostap changes on top
+of 2.10 version hostap. The base hostap checkout point is
+9d07b9447e76059a2ddef2a879c57d0934634188 on which this patch can
+be applied.
+---
+ Makefile.am                        |  19 +
+ hostapd/Makefile                   |   7 +
+ hostapd/Makefile.am                |  72 +++
+ hostapd/config_file.c              |  64 ++-
+ hostapd/ctrl_iface.c               |  70 ++-
+ hostapd/defconfig                  |   9 +
+ hostapd/hostapd_cli.c              |  63 +++
+ hostapd/main.c                     |  29 +-
+ hs20/.DS_Store                     |   0
+ src/.DS_Store                      |   0
+ src/Makefile.am                    | 385 +++++++++++++++
+ src/ap/accounting.c                |   3 +
+ src/ap/ap_config.c                 |   6 +-
+ src/ap/ap_config.h                 |  36 +-
+ src/ap/ap_drv_ops.c                |  55 +++
+ src/ap/ap_drv_ops.h                |  21 +-
+ src/ap/beacon.c                    |  79 ++-
+ src/ap/ctrl_iface_ap.c             |  23 +-
+ src/ap/ctrl_iface_ap.h             |   5 +-
+ src/ap/dfs.c                       |  19 +-
+ src/ap/dfs.h                       |  11 +
+ src/ap/drv_callbacks.c             |  22 +-
+ src/ap/gas_serv.c                  |  15 +-
+ src/ap/greylist.c                  | 766 +++++++++++++++++++++++++++++
+ src/ap/greylist.h                  |  25 +
+ src/ap/hostapd.c                   |  82 ++-
+ src/ap/hostapd.h                   |  22 +-
+ src/ap/ieee802_11.c                | 134 ++++-
+ src/ap/ieee802_11.h                |   5 +
+ src/ap/ieee802_11_he.c             |  11 +
+ src/ap/ieee802_11_ht.c             |  23 +
+ src/ap/ieee802_11_vht.c            |   3 +-
+ src/ap/ieee802_1x.c                | 142 +++++-
+ src/ap/ieee802_1x.h                |   3 +
+ src/ap/sta_info.c                  |  24 +
+ src/ap/sta_info.h                  |   5 +
+ src/ap/utils.c                     |   4 +
+ src/ap/wpa_auth.c                  |  51 +-
+ src/ap/wpa_auth.h                  |   7 +-
+ src/ap/wpa_auth_glue.c             | 116 +++++
+ src/ap/wpa_auth_ie.c               |  33 +-
+ src/ap/wps_hostapd.c               | 253 +++++++++-
+ src/ap/wps_hostapd.h               |   7 +
+ src/common/hw_features_common.c    |   4 +-
+ src/common/ieee802_11_common.c     |  25 +-
+ src/common/ieee802_11_defs.h       |   4 +-
+ src/common/wpa_common.c            |   4 +
+ src/common/wpa_common.h            |   3 +
+ src/common/wpa_ctrl.c              |  40 ++
+ src/crypto/crypto_openssl.c        |   4 +-
+ src/crypto/random.c                |  34 +-
+ src/crypto/tls_openssl.c           |   4 +
+ src/drivers/driver.h               |  42 +-
+ src/drivers/driver_common.c        |   9 +
+ src/drivers/driver_nl80211.c       | 147 +++++-
+ src/drivers/driver_nl80211.h       |   4 +
+ src/drivers/driver_nl80211_event.c |  79 ++-
+ src/drivers/linux_ioctl.c          | 119 +++++
+ src/drivers/netlink.c              |  23 +
+ src/drivers/netlink.h              |   4 +
+ src/drivers/priv_netlink.h         |  18 +
+ src/eapol_auth/eapol_auth_sm.c     |  11 +
+ src/eapol_auth/eapol_auth_sm.h     |   3 +
+ src/radius/radius.c                |  33 +-
+ src/radius/radius.h                |  21 +
+ src/radius/radius_das.c            |  35 +-
+ src/utils/crc32.c                  |   2 +-
+ src/utils/crc32.h                  |   5 +-
+ src/utils/eloop.c                  | 106 ++++
+ src/utils/eloop.h                  |   6 +
+ src/utils/wpa_debug.c              |  58 ++-
+ src/wps/http_server.c              |   5 +
+ src/wps/wps.h                      |  20 +-
+ src/wps/wps_attr_parse.c           |  10 +
+ src/wps/wps_attr_parse.h           |   3 +
+ src/wps/wps_common.c               |  27 +
+ src/wps/wps_defs.h                 |  10 +-
+ src/wps/wps_i.h                    |   7 +
+ src/wps/wps_registrar.c            |  57 ++-
+ src/wps/wps_upnp.c                 | 111 ++++-
+ src/wps/wps_upnp.h                 |   3 +
+ src/wps/wps_upnp_ap.c              |   5 +-
+ src/wps/wps_upnp_i.h               |   3 +
+ src/wps/wps_validate.c             |  24 +-
+ tests/.DS_Store                    |   0
+ wpa_supplicant/.DS_Store           |   0
+ wpadebug/.DS_Store                 |   0
+ 87 files changed, 3733 insertions(+), 128 deletions(-)
+ create mode 100644 Makefile.am
+ create mode 100644 hostapd/Makefile.am
+ create mode 100644 hs20/.DS_Store
+ create mode 100644 src/.DS_Store
+ create mode 100644 src/Makefile.am
+ create mode 100644 src/ap/greylist.c
+ create mode 100644 src/ap/greylist.h
+ create mode 100644 tests/.DS_Store
+ create mode 100644 wpa_supplicant/.DS_Store
+ create mode 100644 wpadebug/.DS_Store
+
+diff --git a/Makefile.am b/Makefile.am
+new file mode 100644
+index 000000000..ba13639dd
+--- /dev/null
++++ b/Makefile.am
+@@ -0,0 +1,19 @@
++##########################################################################
++# If not stated otherwise in this file or this component's LICENSE
++# file the following copyright and licenses apply:
++#
++# Copyright 2015 RDK Management
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++# http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++##########################################################################
++SUBDIRS = src hostapd
+\ No newline at end of file
+diff --git a/hostapd/Makefile b/hostapd/Makefile
+index 3325937ff..fc4a455a0 100644
+--- a/hostapd/Makefile
++++ b/hostapd/Makefile
+@@ -276,6 +276,10 @@ CFLAGS += -DCONFIG_OCV
+ OBJS += ../src/common/ocv.o
+ endif
+ 
++ifdef CONFIG_DRIVER_BRCM
++CFLAGS += -DCONFIG_DRIVER_BRCM
++endif
++
+ ifdef CONFIG_IEEE80211R
+ CFLAGS += -DCONFIG_IEEE80211R -DCONFIG_IEEE80211R_AP
+ OBJS += ../src/ap/wpa_auth_ft.o
+@@ -522,6 +526,9 @@ NEED_AES_UNWRAP=y
+ endif
+ 
+ ifdef CONFIG_WPS
++ifdef CONFIG_DRIVER_BRCM_MAP
++CFLAGS += -DCONFIG_DRIVER_BRCM_MAP
++endif
+ CFLAGS += -DCONFIG_WPS -DEAP_SERVER_WSC
+ OBJS += ../src/utils/uuid.o
+ OBJS += ../src/ap/wps_hostapd.o
+diff --git a/hostapd/Makefile.am b/hostapd/Makefile.am
+new file mode 100644
+index 000000000..0c46a1eb8
+--- /dev/null
++++ b/hostapd/Makefile.am
+@@ -0,0 +1,72 @@
++##########################################################################
++# If not stated otherwise in this file or this component's LICENSE
++# file the following copyright and licenses apply:
++#
++# Copyright 2015 RDK Management
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++# http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++##########################################################################
++AM_CFLAGS = -D_ANSC_LINUX
++AM_CFLAGS += -D_ANSC_USER
++AM_CFLAGS += -D_ANSC_LITTLE_ENDIAN_
++AM_CPPFLAGS = -Wall -Werror
++
++#include ../src/drivers/drivers.mak
++
++##### CLEAR VARS
++
++DRV_CFLAGS =
++DRV_WPA_CFLAGS =
++DRV_AP_CFLAGS =
++DRV_OBJS =
++DRV_WPA_OBJS =
++DRV_AP_OBJS =
++DRV_LIBS =
++DRV_WPA_LIBS =
++DRV_AP_LIBS =
++
++##### COMMON DRIVERS
++
++
++
++
++
++#include ../src/drivers/drivers.mak
++
++AM_LDFLAGS = -lpthread
++AM_LDFLAGS += -lz
++hardware_platform = i686-linux-gnu
++
++AM_CFLAGS += -DCONFIG_CTRL_IFACE
++AM_CFLAGS += -DCONFIG_CTRL_IFACE_UNIX
++AM_CFLAGS += -DCONFIG_FST
++AM_CFLAGS += -DCONFIG_IEEE80211W
++AM_CFLAGS += -DCONFIG_WPS
++AM_CFLAGS += -DCONFIG_WPS_NFC
++#bin_PROGRAMS = hostapd_cli
++
++hostapd_cli_CPPFLAGS = -I$(top_srcdir)/source/hostap-2.10/src -I$(top_srcdir)/source/hostap-2.10/src/utils/ -I$(top_srcdir)/source/hostap-2.10/src/ap -I$(top_srcdir)/source/hostap-2.10/src/common
++
++hostapd_cli_SOURCES = hostapd_cli.c
++
++hostapd_cli_SOURCES += ../src/common/wpa_ctrl.c
++hostapd_cli_SOURCES += ../src/utils/os_unix.c
++hostapd_cli_SOURCES += ../src/utils/eloop.c
++hostapd_cli_SOURCES += ../src/utils/common.c
++hostapd_cli_SOURCES += ../src/utils/wpa_debug.c
++hostapd_cli_SOURCES += ../src/utils/edit_simple.c
++#hostapd_cli_SOURCES += ../src/utils/trace.c
++
++hostapd_cli_SOURCES += ../src/common/cli.c
++
++#hostapd_cli_LDFLAGS = -lrt -ldl
+\ No newline at end of file
+diff --git a/hostapd/config_file.c b/hostapd/config_file.c
+index 8a86ce08b..f616e3daa 100644
+--- a/hostapd/config_file.c
++++ b/hostapd/config_file.c
+@@ -612,22 +612,30 @@ hostapd_config_read_radius_addr(struct hostapd_radius_server **server,
+ static int hostapd_parse_das_client(struct hostapd_bss_config *bss, char *val)
+ {
+ 	char *secret;
+-
++	/* RADIUS greylist allows das secret to be null for open ssid */
++#ifndef FEATURE_SUPPORT_RADIUSGREYLIST
+ 	secret = os_strchr(val, ' ');
+ 	if (secret == NULL)
+ 		return -1;
+-
++#else /* FEATURE_SUPPORT_RADIUSGREYLIST */
++	if (secret)
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 	*secret++ = '\0';
+ 
+ 	if (hostapd_parse_ip_addr(val, &bss->radius_das_client_addr))
+ 		return -1;
+ 
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++	if (secret) {
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 	os_free(bss->radius_das_shared_secret);
+ 	bss->radius_das_shared_secret = (u8 *) os_strdup(secret);
+ 	if (bss->radius_das_shared_secret == NULL)
+ 		return -1;
+ 	bss->radius_das_shared_secret_len = os_strlen(secret);
+-
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++	}
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 	return 0;
+ }
+ #endif /* CONFIG_NO_RADIUS */
+@@ -2415,6 +2423,7 @@ static int hostapd_config_fill(struct hostapd_config *conf,
+ 	} else if (os_strcmp(buf, "skip_inactivity_poll") == 0) {
+ 		bss->skip_inactivity_poll = atoi(pos);
+ 	} else if (os_strcmp(buf, "country_code") == 0) {
++#ifndef CONFIG_DRIVER_BRCM
+ 		if (pos[0] < 'A' || pos[0] > 'Z' ||
+ 		    pos[1] < 'A' || pos[1] > 'Z') {
+ 			wpa_printf(MSG_ERROR,
+@@ -2422,6 +2431,7 @@ static int hostapd_config_fill(struct hostapd_config *conf,
+ 				   line, pos);
+ 			return 1;
+ 		}
++#endif /* CONFIG_DRIVER_BRCM */
+ 		os_memcpy(conf->country, pos, 2);
+ 	} else if (os_strcmp(buf, "country3") == 0) {
+ 		conf->country[2] = strtol(pos, NULL, 16);
+@@ -2431,6 +2441,12 @@ static int hostapd_config_fill(struct hostapd_config *conf,
+ 		conf->ieee80211h = atoi(pos);
+ 	} else if (os_strcmp(buf, "ieee8021x") == 0) {
+ 		bss->ieee802_1x = atoi(pos);
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++	} else if (os_strcmp(buf, "rdk_greylist") == 0) {
++		bss->rdk_greylist = atoi(pos);
++	} else if (os_strcmp(buf, "ap_vlan") == 0) {
++		bss->ap_vlan = atoi(pos);
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 	} else if (os_strcmp(buf, "eapol_version") == 0) {
+ 		int eapol_version = atoi(pos);
+ #ifdef CONFIG_MACSEC
+@@ -3605,6 +3621,8 @@ static int hostapd_config_fill(struct hostapd_config *conf,
+ 		}
+ 	} else if (os_strcmp(buf, "he_6ghz_reg_pwr_type") == 0) {
+ 		conf->he_6ghz_reg_pwr_type = atoi(pos);
++	} else if (os_strcmp(buf, "reg_def_cli_eirp") == 0) {
++		conf->reg_def_cli_eirp = atoi(pos);
+ 	} else if (os_strcmp(buf, "he_oper_chwidth") == 0) {
+ 		conf->he_oper_chwidth = atoi(pos);
+ 	} else if (os_strcmp(buf, "he_oper_centr_freq_seg0_idx") == 0) {
+@@ -4539,6 +4557,42 @@ static int hostapd_config_fill(struct hostapd_config *conf,
+ 		conf->rssi_ignore_probe_request = atoi(pos);
+ 	} else if (os_strcmp(buf, "pbss") == 0) {
+ 		bss->pbss = atoi(pos);
++#ifdef CONFIG_DRIVER_BRCM_MAP
++	} else if (os_strcmp(buf, "map") == 0) {
++		bss->map = atoi(pos);
++	} else if (os_strcmp(buf, "map_bh_ssid") == 0) {
++		size_t bh_ssid_len = os_strlen(pos);
++		if (bh_ssid_len < 1 || bh_ssid_len > SSID_MAX_LEN) {
++			wpa_printf(MSG_ERROR,
++				"Line %d: Invalid invalid map backhaul ssid '%s'", line, pos);
++			return 1;
++		}
++		bss->map_bh_ssid_len = bh_ssid_len;
++		os_memcpy(bss->map_bh_ssid, pos, bh_ssid_len);
++	} else if (os_strcmp(buf, "map_bh_auth") == 0) {
++		bss->map_bh_auth = atoi(pos);
++	} else if (os_strcmp(buf, "map_bh_encr") == 0) {
++		bss->map_bh_encr = atoi(pos);
++	} else if (os_strcmp(buf, "map_bh_psk") == 0) {
++		size_t bh_psk_len = os_strlen(pos);
++		if (bh_psk_len < 8 || bh_psk_len > PMK_LEN_MAX) {
++			wpa_printf(MSG_ERROR,
++				"Line %d: Invalid invalid map backhaul psk '%s'", line, pos);
++			return 1;
++		}
++		bss->map_bh_psk_len = bh_psk_len;
++		os_memcpy(bss->map_bh_psk, pos, bh_psk_len);
++	} else if (os_strcmp(buf, "ft_rrb_lo_sock") == 0) {
++		int val = atoi(pos);
++
++		if (val < 0 || val > 1) {
++			wpa_printf(MSG_ERROR,
++				"Line %d: Invalid ft_rrb_lo_sock value",
++				line);
++			return 1;
++		}
++		conf->ft_rrb_lo_sock = val;
++#endif	/* CONFIG_DRIVER_BRCM_MAP */
+ 	} else if (os_strcmp(buf, "transition_disable") == 0) {
+ 		bss->transition_disable = strtol(pos, NULL, 16);
+ #ifdef CONFIG_AIRTIME_POLICY
+@@ -4701,6 +4755,10 @@ static int hostapd_config_fill(struct hostapd_config *conf,
+ 			return 1;
+ 	} else if (os_strcmp(buf, "rnr") == 0) {
+ 		bss->rnr = atoi(pos);
++#ifdef CONFIG_DRIVER_BRCM
++	} else if (os_strcmp(buf, "spp_amsdu") == 0) {
++		bss->spp_amsdu = atoi(pos);
++#endif /* CONFIG_DRIVER_BRCM */
+ #ifdef CONFIG_IEEE80211BE
+ 	} else if (os_strcmp(buf, "ieee80211be") == 0) {
+ 		conf->ieee80211be = atoi(pos);
+diff --git a/hostapd/ctrl_iface.c b/hostapd/ctrl_iface.c
+index d479006c7..50d189c6c 100644
+--- a/hostapd/ctrl_iface.c
++++ b/hostapd/ctrl_iface.c
+@@ -67,7 +67,9 @@
+ #include "fst/fst_ctrl_iface.h"
+ #include "config_file.h"
+ #include "ctrl_iface.h"
+-
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++#include "ap/greylist.h"
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 
+ #define HOSTAPD_CLI_DUP_VALUE_MAX_LEN 256
+ 
+@@ -443,6 +445,42 @@ static int hostapd_ctrl_iface_nfc_report_handover(struct hostapd_data *hapd,
+ 
+ #endif /* CONFIG_WPS_NFC */
+ 
++#ifdef CONFIG_DRIVER_BRCM_MAP
++static int hostapd_ctrl_iface_wps_map_bh_creds(struct hostapd_data *hapd, char *txt,
++                                         char *buf, size_t buflen)
++{
++        char *pos;
++        char *ssid, *auth = NULL, *encr = NULL, *key = NULL;
++        int ret = -1;
++
++        if (!hapd->wps)
++                return -1;
++
++        ssid = txt;
++        pos = os_strchr(txt, ' ');
++        if (!pos)
++                return -1;
++        *pos++ = '\0';
++
++        auth = pos;
++        pos = os_strchr(pos, ' ');
++        if (pos) {
++                *pos++ = '\0';
++                encr = pos;
++                pos = os_strchr(pos, ' ');
++                if (pos) {
++                        *pos++ = '\0';
++                        key = pos;
++                }
++        }
++
++        if (hostapd_wps_config_map_bh(hapd, ssid, auth, encr, key) < 0) {
++                return os_snprintf(buf, buflen, "FAILED\n");
++        }
++
++        return os_snprintf(buf, buflen, "OK\n");
++}
++#endif  /* CONFIG_DRIVER_BRCM_MAP */
+ 
+ static int hostapd_ctrl_iface_wps_ap_pin(struct hostapd_data *hapd, char *txt,
+ 					 char *buf, size_t buflen)
+@@ -3145,6 +3183,17 @@ static int hostapd_ctrl_iface_get_capability(struct hostapd_data *hapd,
+ 	return -1;
+ }
+ 
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++static int hostapd_ctrl_add_to_greylist(struct hostapd_data *hapd,
++				     const char *txtaddr)
++{
++        if (greylist_add(hapd, txtaddr, false) < 0) {
++		wpa_printf(MSG_ERROR, "Adding %s to greylist failed", txtaddr);
++		return -1;
++	}
++	return 0;
++}
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 
+ #ifdef ANDROID
+ static int hostapd_ctrl_iface_driver_cmd(struct hostapd_data *hapd, char *cmd,
+@@ -3288,6 +3337,11 @@ static int hostapd_ctrl_iface_receive_process(struct hostapd_data *hapd,
+ 	} else if (os_strncmp(buf, "WPS_GET_STATUS", 13) == 0) {
+ 		reply_len = hostapd_ctrl_iface_wps_get_status(hapd, reply,
+ 							      reply_size);
++#ifdef CONFIG_DRIVER_BRCM_MAP
++        } else if (os_strncmp(buf, "WPS_MAPBH_CONFIG ", 17) == 0) {
++                reply_len = hostapd_ctrl_iface_wps_map_bh_creds(hapd, buf + 17,
++                                reply, reply_size);
++#endif /* CONFIG_DRIVER_BRCM_MAP */
+ #ifdef CONFIG_WPS_NFC
+ 	} else if (os_strncmp(buf, "WPS_NFC_TAG_READ ", 17) == 0) {
+ 		if (hostapd_ctrl_iface_wps_nfc_tag_read(hapd, buf + 17))
+@@ -3680,6 +3734,20 @@ static int hostapd_ctrl_iface_receive_process(struct hostapd_data *hapd,
+ 	} else if (os_strncmp(buf, "GET_CAPABILITY ", 15) == 0) {
+ 		reply_len = hostapd_ctrl_iface_get_capability(
+ 			hapd, buf + 15, reply, reply_size);
++#ifdef CONFIG_DRIVER_BRCM
++	} else if (os_strncmp(buf, "START_BSS", 9) == 0) {
++		if (hostapd_ctrl_iface_start_bss(hapd))
++			reply_len = -1;
++	} else if (os_strncmp(buf, "STOP_BSS", 8) == 0) {
++		if (hostapd_ctrl_iface_stop_bss(hapd))
++			reply_len = -1;
++#endif /* CONFIG_DRIVER_BRCM */
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++	} else if (os_strncmp(buf, "ADD_TO_GREYLIST ", 16) == 0) {
++                if (hostapd_ctrl_add_to_greylist(hapd,
++						buf + 16))
++			reply_len = -1;
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ #ifdef CONFIG_PASN
+ 	} else if (os_strcmp(buf, "PTKSA_CACHE_LIST") == 0) {
+ 		reply_len = ptksa_cache_list(hapd->ptksa, reply, reply_size);
+diff --git a/hostapd/defconfig b/hostapd/defconfig
+index a9eab4d9c..f1453395f 100644
+--- a/hostapd/defconfig
++++ b/hostapd/defconfig
+@@ -30,6 +30,15 @@ CONFIG_DRIVER_NL80211=y
+ # Use libnl v2.0 (or 3.0) libraries.
+ #CONFIG_LIBNL20=y
+ 
++ifneq ($(STB),1)
++CFLAGS += -I$(LIBNL_DIR)/install/include/libnl3
++LIBS += -L$(LIBNL_DIR)/install/lib
++else
++LIBS += -lm
++CFLAGS += -I$(LIBNL_DIR)/include/libnl3
++LIBS += -L$(LIBNL_DIR)/lib/static
++endif # STB
++
+ # Use libnl 3.2 libraries (if this is selected, CONFIG_LIBNL20 is ignored)
+ CONFIG_LIBNL32=y
+ 
+diff --git a/hostapd/hostapd_cli.c b/hostapd/hostapd_cli.c
+index 60396f3da..8b4e1982a 100644
+--- a/hostapd/hostapd_cli.c
++++ b/hostapd/hostapd_cli.c
+@@ -644,6 +644,30 @@ static int hostapd_cli_cmd_wps_config(struct wpa_ctrl *ctrl, int argc,
+ 			 ssid_hex, argv[1]);
+ 	return wpa_ctrl_command(ctrl, buf);
+ }
++#ifdef CONFIG_DRIVER_BRCM_MAP
++static int hostapd_cli_cmd_wps_mapbh_config(struct wpa_ctrl *ctrl, int argc,
++                                      char *argv[])
++{
++        char buf[256];
++
++        if (argc < 1) {
++                printf("Invalid 'wps_mapbh_config' command - at least two arguments "
++                       "are required.\n");
++                return -1;
++        }
++
++        if (argc > 3)
++                snprintf(buf, sizeof(buf), "WPS_MAPBH_CONFIG %s %s %s %s",
++                         argv[0], argv[1], argv[2], argv[3]);
++        else if (argc > 2)
++                snprintf(buf, sizeof(buf), "WPS_MAPBH_CONFIG %s %s %s",
++                        argv[0], argv[1], argv[2]);
++        else
++                snprintf(buf, sizeof(buf), "WPS_MAPBH_CONFIG %s %s",
++                         argv[0], argv[1]);
++        return wpa_ctrl_command(ctrl, buf);
++}
++#endif  /* CONFIG_DRIVER_BRCM_MAP */
+ #endif /* CONFIG_WPS */
+ 
+ 
+@@ -1540,6 +1564,20 @@ static int hostapd_cli_cmd_reload_wpa_psk(struct wpa_ctrl *ctrl, int argc,
+ 	return wpa_ctrl_command(ctrl, "RELOAD_WPA_PSK");
+ }
+ 
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++static int hostapd_cli_add_to_greylist(struct wpa_ctrl *ctrl, int argc,
++					  char *argv[])
++{
++	char buf[64];
++        if (argc != 1) {
++                printf("Invalid 'add_to_greylist' command - exactly one argument, STA "
++                       "address, is required.\n");
++                return -1;
++        }
++	snprintf(buf, sizeof(buf), "ADD_TO_GREYLIST %s", argv[0]);
++	return wpa_ctrl_command(ctrl, buf);
++}
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 
+ #ifdef ANDROID
+ static int hostapd_cli_cmd_driver(struct wpa_ctrl *ctrl, int argc, char *argv[])
+@@ -1548,6 +1586,17 @@ static int hostapd_cli_cmd_driver(struct wpa_ctrl *ctrl, int argc, char *argv[])
+ }
+ #endif /* ANDROID */
+ 
++#ifdef CONFIG_DRIVER_BRCM
++static int hostapd_cli_cmd_start_bss(struct wpa_ctrl *ctrl, int argc, char *argv[])
++{
++	return wpa_ctrl_command(ctrl, "START_BSS");
++}
++
++static int hostapd_cli_cmd_stop_bss(struct wpa_ctrl *ctrl, int argc, char *argv[])
++{
++	return wpa_ctrl_command(ctrl, "STOP_BSS");
++}
++#endif /* CONFIG_DRIVER_BRCM */
+ 
+ struct hostapd_cli_cmd {
+ 	const char *cmd;
+@@ -1610,6 +1659,10 @@ static const struct hostapd_cli_cmd hostapd_cli_commands[] = {
+ 	  "<SSID> <auth> <encr> <key> = configure AP" },
+ 	{ "wps_get_status", hostapd_cli_cmd_wps_get_status, NULL,
+ 	  "= show current WPS status" },
++#ifdef CONFIG_DRIVER_BRCM_MAP
++        { "wps_mapbh_config", hostapd_cli_cmd_wps_mapbh_config, NULL,
++          "<SSID> <auth> <encr> <key> = update multiap backhaul config" },
++#endif /* CONFIG_DRIVER_BRCM_MAP */
+ #endif /* CONFIG_WPS */
+ 	{ "disassoc_imminent", hostapd_cli_cmd_disassoc_imminent, NULL,
+ 	  "= send Disassociation Imminent notification" },
+@@ -1740,10 +1793,20 @@ static const struct hostapd_cli_cmd hostapd_cli_commands[] = {
+ 	  "<addr> [req_mode=] <measurement request hexdump>  = send a Beacon report request to a station" },
+ 	{ "reload_wpa_psk", hostapd_cli_cmd_reload_wpa_psk, NULL,
+ 	  "= reload wpa_psk_file only" },
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++        { "add_to_greylist", hostapd_cli_add_to_greylist, NULL,
++          "<addr> = add a station to greylist" },
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ #ifdef ANDROID
+ 	{ "driver", hostapd_cli_cmd_driver, NULL,
+ 	  "<driver sub command> [<hex formatted data>] = send driver command data" },
+ #endif /* ANDROID */
++#ifdef CONFIG_DRIVER_BRCM
++	{ "start_bss", hostapd_cli_cmd_start_bss, NULL,
++	  "= start beaconing on BSS (BSS up)" },
++	{ "stop_bss", hostapd_cli_cmd_stop_bss, NULL,
++	  "= stop beaconing on BSS (BSS down)" },
++#endif /* CONFIG_DRIVER_BRCM */
+ 	{ NULL, NULL, NULL, NULL }
+ };
+ 
+diff --git a/hostapd/main.c b/hostapd/main.c
+index 4503d24ae..e1867b8eb 100644
+--- a/hostapd/main.c
++++ b/hostapd/main.c
+@@ -31,15 +31,22 @@
+ #include "config_file.h"
+ #include "eap_register.h"
+ #include "ctrl_iface.h"
+-
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++#include "ap/greylist.h"
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
++#if defined(CONFIG_DRIVER_BRCM) && defined(BCM_CEVENT)
++#include "ce_shared.h"
++#include "security_ipc.h"
++#endif /* CONFIG_DRIVER_BRCM && BCM_CEVENT */
+ 
+ struct hapd_global {
+ 	void **drv_priv;
+ 	size_t drv_count;
+ };
+ 
++#if 0
+ static struct hapd_global global;
+-
++#endif
+ 
+ #ifndef CONFIG_NO_HOSTAPD_LOGGER
+ static void hostapd_logger_cb(void *ctx, const u8 *addr, unsigned int module,
+@@ -150,7 +157,7 @@ static void hostapd_logger_cb(void *ctx, const u8 *addr, unsigned int module,
+ /**
+  * hostapd_driver_init - Preparate driver interface
+  */
+-static int hostapd_driver_init(struct hostapd_iface *iface)
++int hostapd_driver_init(struct hostapd_iface *iface)
+ {
+ 	struct wpa_init_params params;
+ 	size_t i;
+@@ -254,7 +261,7 @@ static int hostapd_driver_init(struct hostapd_iface *iface)
+  * or more BSSes sharing the same radio) and allocate memory for the BSS
+  * interfaces. No actual driver operations are started.
+  */
+-static struct hostapd_iface *
++struct hostapd_iface *
+ hostapd_interface_init(struct hapd_interfaces *interfaces, const char *if_name,
+ 		       const char *config_fname, int debug)
+ {
+@@ -332,7 +339,7 @@ static void handle_dump_state(int sig, void *signal_ctx)
+ #endif /* CONFIG_NATIVE_WINDOWS */
+ 
+ 
+-static int hostapd_global_init(struct hapd_interfaces *interfaces,
++int hostapd_global_init(struct hapd_interfaces *interfaces,
+ 			       const char *entropy_file)
+ {
+ 	int i;
+@@ -378,7 +385,7 @@ static int hostapd_global_init(struct hapd_interfaces *interfaces,
+ }
+ 
+ 
+-static void hostapd_global_deinit(const char *pid_file, int eloop_initialized)
++void hostapd_global_deinit(const char *pid_file, int eloop_initialized)
+ {
+ 	int i;
+ 
+@@ -409,7 +416,7 @@ static void hostapd_global_deinit(const char *pid_file, int eloop_initialized)
+ }
+ 
+ 
+-static int hostapd_global_run(struct hapd_interfaces *ifaces, int daemonize,
++int hostapd_global_run(struct hapd_interfaces *ifaces, int daemonize,
+ 			      const char *pid_file)
+ {
+ #ifdef EAP_SERVER_TNC
+@@ -617,7 +624,7 @@ static int gen_uuid(const char *txt_addr)
+ #define HOSTAPD_CLEANUP_INTERVAL 10
+ #endif /* HOSTAPD_CLEANUP_INTERVAL */
+ 
+-static int hostapd_periodic_call(struct hostapd_iface *iface, void *ctx)
++int hostapd_periodic_call(struct hostapd_iface *iface, void *ctx)
+ {
+ 	hostapd_periodic_iface(iface);
+ 	return 0;
+@@ -625,7 +632,7 @@ static int hostapd_periodic_call(struct hostapd_iface *iface, void *ctx)
+ 
+ 
+ /* Periodic cleanup tasks */
+-static void hostapd_periodic(void *eloop_ctx, void *timeout_ctx)
++void hostapd_periodic(void *eloop_ctx, void *timeout_ctx)
+ {
+ 	struct hapd_interfaces *interfaces = eloop_ctx;
+ 
+@@ -889,6 +896,10 @@ int main(int argc, char *argv[])
+ 
+ 	hostapd_global_ctrl_iface_init(&interfaces);
+ 
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++	greylist_load(&interfaces);
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
++
+ 	if (hostapd_global_run(&interfaces, daemonize, pid_file)) {
+ 		wpa_printf(MSG_ERROR, "Failed to start eloop");
+ 		goto out;
+diff --git a/hs20/.DS_Store b/hs20/.DS_Store
+new file mode 100644
+index 000000000..e69de29bb
+diff --git a/src/.DS_Store b/src/.DS_Store
+new file mode 100644
+index 000000000..e69de29bb
+diff --git a/src/Makefile.am b/src/Makefile.am
+new file mode 100644
+index 000000000..0044634df
+--- /dev/null
++++ b/src/Makefile.am
+@@ -0,0 +1,385 @@
++##########################################################################
++# If not stated otherwise in this file or this component's LICENSE
++# file the following copyright and licenses apply:
++#
++# Copyright 2015 RDK Management
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++# http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++##########################################################################
++AM_CFLAGS = -D_ANSC_LINUX
++AM_CFLAGS += -D_ANSC_USER
++if CCSP_ARCH_ARM
++AM_CFLAGS += -D_ANSC_LITTLE_ENDIAN_
++endif
++
++if CCSP_ARCH_ATOM
++AM_CFLAGS += -D_ANSC_LITTLE_ENDIAN_
++endif
++
++if CCSP_ARCH_PC
++AM_CFLAGS += -D_ANSC_LITTLE_ENDIAN_
++endif
++AM_CFLAGS += -DEAP_PWD
++AM_CPPFLAGS = -Wall -Werror
++ACLOCAL_AMFLAGS = -I m4
++hardware_platform = i686-linux-gnu
++
++lib_LTLIBRARIES = libhostap.la
++
++libhostap_la_CPPFLAGS = -I$(top_srcdir)/source/hostap-2.10/src -I$(top_srcdir)/source/hostap-2.10/src/utils/ -I$(top_srcdir)/source/hostap-2.10/src/ap
++libhostap_la_CPPFLAGS += -I$(top_srcdir)/libnl/include
++libhostap_la_CPPFLAGS += -I$(top_srcdir)/openssl/usr/include/
++
++libhostap_la_SOURCES = ap/wpa_auth_glue.c
++libhostap_la_SOURCES += ap/wpa_auth.c
++libhostap_la_SOURCES += ap/wpa_auth_ie.c
++libhostap_la_SOURCES += ap/wpa_auth_ft.c
++libhostap_la_SOURCES += ap/ap_drv_ops.c
++libhostap_la_SOURCES += ap/pmksa_cache_auth.c
++libhostap_la_SOURCES += ap/tkip_countermeasures.c
++libhostap_la_SOURCES += ap/ieee802_11.c
++libhostap_la_SOURCES += ap/ieee802_11_he.c
++libhostap_la_SOURCES += ap/ieee802_11_ht.c
++libhostap_la_SOURCES += ap/ieee802_11_vht.c
++libhostap_la_SOURCES += ap/ieee802_11_shared.c
++libhostap_la_SOURCES += ap/beacon.c
++libhostap_la_SOURCES += ap/dfs.c
++libhostap_la_SOURCES += ap/sta_info.c
++libhostap_la_SOURCES += ap/ieee802_1x.c
++libhostap_la_SOURCES += ap/accounting.c
++libhostap_la_SOURCES += ap/utils.c
++libhostap_la_SOURCES += ap/ap_config.c
++libhostap_la_SOURCES += ap/ieee802_11_auth.c
++libhostap_la_SOURCES += ap/hw_features.c
++libhostap_la_SOURCES += ap/wmm.c
++libhostap_la_SOURCES += ap/hostapd.c
++libhostap_la_SOURCES += ap/wps_hostapd.c
++libhostap_la_SOURCES += ap/rrm.c
++libhostap_la_SOURCES += ap/eap_user_db.c
++libhostap_la_SOURCES += ap/neighbor_db.c
++libhostap_la_SOURCES += ap/ap_mlme.c
++libhostap_la_SOURCES += ap/ap_list.c
++libhostap_la_SOURCES += ap/authsrv.c
++libhostap_la_SOURCES += ap/bss_load.c
++libhostap_la_SOURCES += ap/vlan_init.c
++libhostap_la_SOURCES += ap/vlan.c
++libhostap_la_SOURCES += ap/vlan_ifconfig.c
++libhostap_la_SOURCES += ap/drv_callbacks.c
++libhostap_la_SOURCES += ap/eth_p_oui.c
++libhostap_la_SOURCES += ap/ctrl_iface_ap.c
++libhostap_la_SOURCES += ap/greylist.c
++libhostap_la_SOURCES += ap/wnm_ap.c
++
++libhostap_la_SOURCES += radius/radius.c
++libhostap_la_SOURCES += radius/radius_client.c
++libhostap_la_SOURCES += radius/radius_das.c
++
++#libhostap_la_SOURCES += eap_register.c
++libhostap_la_SOURCES += eap_common/eap_common.c
++libhostap_la_SOURCES += eap_common/eap_peap_common.c
++libhostap_la_SOURCES += eap_common/eap_psk_common.c
++libhostap_la_SOURCES += eap_common/eap_pax_common.c
++libhostap_la_SOURCES += eap_common/eap_sake_common.c
++libhostap_la_SOURCES += eap_common/eap_gpsk_common.c
++libhostap_la_SOURCES += eap_common/chap.c
++libhostap_la_SOURCES += eap_common/eap_pwd_common.c
++#libhostap_la_SOURCES += eap_common/eap_sim_common.c
++#libhostap_la_SOURCES += eap_common/eap_fast_common.c
++libhostap_la_SOURCES += eap_common/eap_ikev2_common.c
++libhostap_la_SOURCES += eap_common/ikev2_common.c
++libhostap_la_SOURCES += eap_common/eap_wsc_common.c
++#libhostap_la_SOURCES += eap_common/eap_teap_common.c
++
++libhostap_la_SOURCES += eap_peer/eap_tls.c
++libhostap_la_SOURCES += eap_peer/eap_peap.c
++libhostap_la_SOURCES += eap_peer/eap_ttls.c
++libhostap_la_SOURCES += eap_peer/eap_md5.c
++libhostap_la_SOURCES += eap_peer/eap_mschapv2.c
++libhostap_la_SOURCES += eap_peer/mschapv2.c
++libhostap_la_SOURCES += eap_peer/eap_otp.c
++libhostap_la_SOURCES += eap_peer/eap_gtc.c
++libhostap_la_SOURCES += eap_peer/eap_leap.c
++libhostap_la_SOURCES += eap_peer/eap_psk.c
++libhostap_la_SOURCES += eap_peer/eap_pax.c
++libhostap_la_SOURCES += eap_peer/eap_sake.c
++libhostap_la_SOURCES += eap_peer/eap_gpsk.c
++libhostap_la_SOURCES += eap_peer/eap.c
++libhostap_la_SOURCES += eap_peer/eap_methods.c
++libhostap_la_SOURCES += eap_peer/eap_tls_common.c
++libhostap_la_SOURCES += eap_peer/eap_pwd.c
++libhostap_la_SOURCES += eap_server/eap_server_tls.c
++libhostap_la_SOURCES += eap_server/eap_server_peap.c
++#libhostap_la_SOURCES += eap_server/eap_server_ttls.c
++libhostap_la_SOURCES += eap_server/eap_server_md5.c
++#libhostap_la_SOURCES += eap_server/eap_server_mschapv2.c
++libhostap_la_SOURCES += eap_server/eap_server_gtc.c
++libhostap_la_SOURCES += eap_server/eap_server_psk.c
++libhostap_la_SOURCES += eap_server/eap_server_pax.c
++libhostap_la_SOURCES += eap_server/eap_server_sake.c
++libhostap_la_SOURCES += eap_server/eap_server_gpsk.c
++libhostap_la_SOURCES += eap_server/eap_server.c
++libhostap_la_SOURCES += eap_server/eap_server_identity.c
++libhostap_la_SOURCES += eap_server/eap_server_methods.c
++libhostap_la_SOURCES += eap_server/eap_server_tls_common.c
++libhostap_la_SOURCES += eap_server/eap_server_pwd.c
++libhostap_la_SOURCES += eap_server/eap_server_tnc.c
++libhostap_la_SOURCES += eap_server/tncs.c
++libhostap_la_SOURCES += eap_server/eap_server_ikev2.c
++libhostap_la_SOURCES += eap_server/eap_server_wsc.c
++#libhostap_la_SOURCES += eap_server/eap_server_teap.c
++#libhostap_la_SOURCES += eap_server/eap_server_fast.c
++#libhostap_la_SOURCES += eap_server/eap_server_aka.c
++#libhostap_la_SOURCES += eap_server/eap_server_sim.c
++#libhostap_la_SOURCES += eap_server/eap_sim_db.c
++libhostap_la_SOURCES += eap_server/ikev2.c
++libhostap_la_SOURCES += eapol_supp/eapol_supp_sm.c
++libhostap_la_SOURCES += rsn_supp/wpa.c
++libhostap_la_SOURCES += rsn_supp/wpa_ie.c
++libhostap_la_SOURCES += rsn_supp/wpa_ft.c
++libhostap_la_SOURCES += rsn_supp/pmksa_cache.c
++libhostap_la_SOURCES += rsn_supp/preauth.c
++
++libhostap_la_SOURCES += common/wpa_common.c
++libhostap_la_SOURCES += common/wpa_ctrl.c
++libhostap_la_SOURCES += common/wpa_helpers.c
++libhostap_la_SOURCES += common/ieee802_11_common.c
++libhostap_la_SOURCES += common/hw_features_common.c
++libhostap_la_SOURCES += common/ctrl_iface_common.c
++libhostap_la_SOURCES += common/sae.c
++libhostap_la_SOURCES += common/dragonfly.c
++
++libhostap_la_SOURCES += utils/wpa_debug.c
++libhostap_la_SOURCES += utils/eloop.c
++libhostap_la_SOURCES += utils/os_unix.c
++libhostap_la_SOURCES += utils/common.c
++libhostap_la_SOURCES += utils/wpabuf.c
++libhostap_la_SOURCES += utils/ip_addr.c
++libhostap_la_SOURCES += utils/uuid.c
++libhostap_la_SOURCES += utils/base64.c
++libhostap_la_SOURCES += utils/crc32.c
++
++libhostap_la_SOURCES += crypto/random.c
++#libhostap_la_SOURCES += crypto/md5.c
++#libhostap_la_SOURCES += crypto/md5-internal.c
++#libhostap_la_SOURCES += crypto/sha1.c
++libhostap_la_SOURCES += crypto/sha256-kdf.c
++#libhostap_la_SOURCES += crypto/sha1-internal.c
++#libhostap_la_SOURCES += crypto/sha1-pbkdf2.c
++libhostap_la_SOURCES += crypto/sha1-prf.c
++#libhostap_la_SOURCES += crypto/aes-cbc.c
++#libhostap_la_SOURCES += crypto/aes-ccm.c
++libhostap_la_SOURCES += crypto/aes-ctr.c
++libhostap_la_SOURCES += crypto/aes-eax.c
++libhostap_la_SOURCES += crypto/aes-encblock.c
++#libhostap_la_SOURCES += crypto/aes-gcm.c
++#libhostap_la_SOURCES += crypto/aes-internal.c
++#libhostap_la_SOURCES += crypto/aes-internal-dec.c
++#libhostap_la_SOURCES += crypto/aes-internal-enc.c
++libhostap_la_SOURCES += crypto/aes-omac1.c
++libhostap_la_SOURCES += crypto/aes-siv.c
++#libhostap_la_SOURCES += crypto/aes-wrap.c
++#libhostap_la_SOURCES += crypto/aes-unwrap.c
++#libhostap_la_SOURCES += crypto/rc4.c
++libhostap_la_SOURCES += crypto/tls_none.c
++#libhostap_la_SOURCES += crypto/tls_internal.c
++libhostap_la_SOURCES += crypto/ms_funcs.c
++libhostap_la_SOURCES += crypto/dh_groups.c
++#libhostap_la_SOURCES += crypto/des-internal.c
++#libhostap_la_SOURCES += crypto/dh_group5.c
++#libhostap_la_SOURCES += crypto/md4-internal.c
++#libhostap_la_SOURCES += crypto/milenage.c
++libhostap_la_SOURCES += crypto/sha1-tlsprf.c
++#libhostap_la_SOURCES += crypto/sha1-tprf.c
++#libhostap_la_SOURCES += crypto/sha256.c
++libhostap_la_SOURCES += crypto/sha256-prf.c
++libhostap_la_SOURCES += crypto/sha256-tlsprf.c
++#libhostap_la_SOURCES += crypto/sha256-internal.c
++#libhostap_la_SOURCES += crypto/crypto_internal.c
++#libhostap_la_SOURCES += crypto/crypto_internal-cipher.c
++#libhostap_la_SOURCES += crypto/crypto_internal-modexp.c
++#libhostap_la_SOURCES += crypto/crypto_internal-rsa.c
++#libhostap_la_SOURCES += crypto/sha384.c
++libhostap_la_SOURCES += crypto/sha384-prf.c
++libhostap_la_SOURCES += crypto/sha384-kdf.c
++#libhostap_la_SOURCES += crypto/sha384-internal.c
++#libhostap_la_SOURCES += crypto/sha512-internal.c
++libhostap_la_SOURCES += crypto/sha512-kdf.c
++libhostap_la_SOURCES += crypto/sha512-prf.c
++#libhostap_la_SOURCES += crypto/fips_prf_internal.c
++#libhostap_la_SOURCES += crypto/tls_openssl.c
++libhostap_la_SOURCES += crypto/crypto_openssl.c
++
++#libhostap_la_SOURCES += crypto/dh_group5.c
++#libhostap_la_SOURCES += crypto/dh_groups.c
++#libhostap_la_SOURCES += crypto/sha256-prf.c
++#libhostap_la_SOURCES += crypto/sha256.c
++#libhostap_la_SOURCES += crypto/sha256-internal.c
++#libhostap_la_SOURCES += crypto/crypto_internal-modexp.c
++#libhostap_la_SOURCES += tls/bignum.c
++
++libhostap_la_SOURCES += eapol_auth/eapol_auth_sm.c
++libhostap_la_SOURCES += eapol_auth/eapol_auth_dump.c
++
++libhostap_la_SOURCES += l2_packet/l2_packet_linux.c
++libhostap_la_SOURCES += drivers/netlink.c
++libhostap_la_SOURCES += drivers/drivers.c #Added for hostapd.c support, will be removed later once only needed API(s) used
++libhostap_la_SOURCES += drivers/driver_common.c #event_to_string API, will be removed later once only needed API(s) used
++
++#AM_CFLAGS += -DCONFIG_DRIVER_NL80211
++libhostap_la_SOURCES += drivers/driver_nl80211.c
++libhostap_la_SOURCES += drivers/driver_nl80211_android.c
++libhostap_la_SOURCES += drivers/driver_nl80211_capa.c
++libhostap_la_SOURCES += drivers/driver_nl80211_event.c
++libhostap_la_SOURCES += drivers/driver_nl80211_monitor.c
++libhostap_la_SOURCES += drivers/driver_nl80211_scan.c
++libhostap_la_SOURCES += drivers/linux_ioctl.c
++libhostap_la_SOURCES += drivers/rfkill.c
++libhostap_la_SOURCES += drivers/driver_hostap.c
++libhostap_la_SOURCES += utils/radiotap.c
++libhostap_la_SOURCES += ap/acs.c
++
++libhostap_la_SOURCES += wps/wps.c
++libhostap_la_SOURCES += wps/wps_attr_build.c
++libhostap_la_SOURCES += wps/wps_registrar.c
++libhostap_la_SOURCES += wps/wps_dev_attr.c
++libhostap_la_SOURCES += wps/wps_common.c
++libhostap_la_SOURCES += wps/wps_enrollee.c
++libhostap_la_SOURCES += wps/wps_attr_parse.c
++libhostap_la_SOURCES += wps/wps_attr_process.c
++
++libhostap_la_SOURCES += tls/asn1.c
++#libhostap_la_SOURCES += tls/bignum.c
++#libhostap_la_SOURCES += tls/pkcs1.c
++#libhostap_la_SOURCES += tls/pkcs5.c
++#libhostap_la_SOURCES += tls/pkcs8.c
++#libhostap_la_SOURCES += tls/rsa.c
++#libhostap_la_SOURCES += tls/tlsv1_client.c
++#libhostap_la_SOURCES += tls/tlsv1_client_read.c
++#libhostap_la_SOURCES += tls/tlsv1_client_write.c
++#libhostap_la_SOURCES += tls/tlsv1_common.c
++#libhostap_la_SOURCES += tls/tlsv1_cred.c
++#libhostap_la_SOURCES += tls/tlsv1_record.c
++#libhostap_la_SOURCES += tls/tlsv1_server.c
++#libhostap_la_SOURCES += tls/tlsv1_server_read.c
++#libhostap_la_SOURCES += tls/tlsv1_server_write.c
++#libhostap_la_SOURCES += tls/tlsv1_client_ocsp.c
++#libhostap_la_SOURCES += tls/x509v3.c
++
++AM_CFLAGS += -DCONFIG_HS20
++AM_CFLAGS += -DCONFIG_INTERWORKING
++libhostap_la_SOURCES += ap/hs20.c
++libhostap_la_SOURCES += ap/gas_serv.c
++libhostap_la_SOURCES += common/gas.c
++libhostap_la_SOURCES += ../hostapd/main.c
++
++libhostap_la_SOURCES += ../hostapd/ctrl_iface.c
++libhostap_la_SOURCES += ../hostapd/config_file.c
++libhostap_la_SOURCES += ../hostapd/eap_register.c
++
++#COBJECTS = $(libhostap_la_SOURCES:.c=.o)  # expands to list of object files
++
++#
++AM_CFLAGS += -DHOSTAPD #applicable ap
++AM_CFLAGS += -DNEED_AP_MLME    #applicable ap
++AM_CFLAGS += -DCONFIG_IEEE80211R_AP    #applicable ap
++AM_CFLAGS += -DCONFIG_ETH_P_OUI    #applicable ap
++#AM_CFLAGS += -DCONFIG_INTERWORKING #applicable ap
++#AM_CFLAGS += -DCONFIG_WPS  #applicable ap
++#AM_CFLAGS += -DCONFIG_PROXYARP #applicable ap
++#AM_CFLAGS += -DCONFIG_IPV6 #applicable for ap/ radius/ utils/
++#AM_CFLAGS += -DCONFIG_IAPP #applicable ap
++#AM_CFLAGS += -DCONFIG_AIRTIME_POLICY   #applicable ap
++#
++##applicable for common/
++AM_CFLAGS += -DCONFIG_IEEE80211R #ap/
++AM_CFLAGS += -DCONFIG_IEEE80211W #ap/
++#AM_CFLAGS += -DCONFIG_HS20 #ap/ eap_server/
++AM_CFLAGS += -DCONFIG_SAE
++AM_CFLAGS += -DCONFIG_SUITE
++AM_CFLAGS += -DCONFIG_SUITEB
++AM_CFLAGS += -DCONFIG_SUITEB192
++#
++##applicable for utils/
++#AM_CFLAGS += -DCONFIG_DEBUG_FILE
++#
++##applicable for crypto
++AM_CFLAGS += -DCONFIG_CRYPTO_INTERNAL
++AM_CFLAGS += -DCONFIG_TLS_INTERNAL_CLIENT
++AM_CFLAGS += -DCONFIG_TLS_INTERNAL_SERVER
++#AM_CFLAGS += -DALL_DH_GROUPS
++AM_CFLAGS += -DCONFIG_SHA256
++AM_CFLAGS += -DCONFIG_SHA384
++AM_CFLAGS += -DCONFIG_SHA512
++AM_CFLAGS += -DCONFIG_HMAC_SHA384_KDF
++AM_CFLAGS += -DCONFIG_INTERNAL_SHA384
++##endif
++AM_CFLAGS += -DLINUX_PORT -DRDK_PORT -DCONFIG_CRYPTO_INTERNAL -DCONFIG_DEBUG_LINUX_TRACING -DCONFIG_WPS -DCONFIG_IEEE80211AC -DCONFIG_IEEE80211AX -DCONFIG_IEEE80211N
++#AM_CFLAGS += -DCONFIG_WPS -DCONFIG_CTRL_IFACE -DCONFIG_CTRL_IFACE_UNIX -DCONFIG_INTERNAL_LIBTOMMATH //master
++#AM_CFLAGS += -DLINUX_PORT -DCONFIG_IEEE80211N -DCONFIG_IEEE80211AC -DCONFIG_WPS
++#AM_CFLAGS += -DCONFIG_EAP -DCONFIG_EAP_MD5 -DCONFIG_EAP_TLS -DCONFIG_EAP_MSCHAPV2 -DCONFIG_EAP_PEAP -DCONFIG_EAP_GTC -DCONFIG_EAP_TTLS
++#AM_CFLAGS += -DEAP_TLS
++#AM_CFLAGS += -DEAP_PEAP
++#AM_CFLAGS += -DEAP_TTLS
++#AM_CFLAGS += -DEAP_MD5
++#AM_CFLAGS += -DEAP_MSCHAPv2
++#AM_CFLAGS += -DEAP_GTC
++#AM_CFLAGS += -DEAP_OTP
++#AM_CFLAGS += -DEAP_LEAP
++#AM_CFLAGS += -DEAP_PSK
++#AM_CFLAGS += -DEAP_PAX
++#AM_CFLAGS += -DEAP_SAKE
++#AM_CFLAGS += -DEAP_GPSK -DEAP_GPSK_SHA256
++AM_CFLAGS += -DCONFIG_WEP
++
++AM_CFLAGS += -DEAP_SERVER_IDENTITY
++AM_CFLAGS += -DEAP_SERVER_TLS
++AM_CFLAGS += -DEAP_SERVER_PEAP
++#AM_CFLAGS += -DEAP_SERVER_TTLS
++AM_CFLAGS += -DEAP_SERVER_MD5
++#AM_CFLAGS += -DEAP_SERVER_MSCHAPV2
++AM_CFLAGS += -DEAP_SERVER_GTC
++AM_CFLAGS += -DEAP_SERVER_PSK
++AM_CFLAGS += -DEAP_SERVER_PAX
++AM_CFLAGS += -DEAP_SERVER_SAKE
++AM_CFLAGS += -DEAP_SERVER_GPSK
++AM_CFLAGS += -DEAP_SERVER_GPSK_SHA256
++AM_CFLAGS += -DEAP_SERVER_PWD
++AM_CFLAGS += -DEAP_SERVER_TNC
++AM_CFLAGS += -DEAP_SERVER_IKEV2
++AM_CFLAGS += -DEAP_SERVER_WSC
++#AM_CFLAGS += -DEAP_SERVER_TEAP
++#AM_CFLAGS += -DEAP_SERVER_FAST
++#AM_CFLAGS += -DEAP_SERVER_AKA_PRIME
++#AM_CFLAGS += -DEAP_SERVER_AKA
++#AM_CFLAGS += -DEAP_SERVER_SIM
++#AM_CFLAGS += -DEAP_SERVER_TLV
++AM_CFLAGS += -DEAP_SERVER_UNAUTH_TLS
++
++AM_CFLAGS += -DIEEE8021X_EAPOL
++
++AM_CFLAGS += -DEAP_SERVER
++
++AM_CFLAGS += -DCONFIG_INTERNAL_LIBTOMMATH
++AM_CFLAGS += -DCONFIG_CRYPTO_INTERNAL
++AM_CFLAGS += -DCONFIG_TLSV11
++AM_CFLAGS += -DCONFIG_TLSV12
++
++#Logger compilation
++AM_CFLAGS += -DCONFIG_DEBUG_FILE
++
++#Needed to compile
++AM_CFLAGS += -DCONFIG_ECC
++
++#AM_CFLAGS += -DCONFIG_CTRL_IFACE_UDP
++
++libhostap_la_LDFLAGS = -lpthread -ldl -lssl
+diff --git a/src/ap/accounting.c b/src/ap/accounting.c
+index 9fc1886a2..5a8974e3d 100644
+--- a/src/ap/accounting.c
++++ b/src/ap/accounting.c
+@@ -185,6 +185,8 @@ static int accounting_sta_update_stats(struct hostapd_data *hapd,
+ 		sta->last_tx_bytes_lo = data->tx_bytes;
+ 	}
+ 
++#if 0
++//Disabling the below print temporarily as stats features are not completely implemented and below print reports incorrect value
+ 	hostapd_logger(hapd, sta->addr, HOSTAPD_MODULE_RADIUS,
+ 		       HOSTAPD_LEVEL_DEBUG,
+ 		       "updated TX/RX stats: rx_bytes=%llu [%u:%u] tx_bytes=%llu [%u:%u] bytes_64bit=%d",
+@@ -193,6 +195,7 @@ static int accounting_sta_update_stats(struct hostapd_data *hapd,
+ 		       data->tx_bytes, sta->last_tx_bytes_hi,
+ 		       sta->last_tx_bytes_lo,
+ 		       data->bytes_64bit);
++#endif
+ 
+ 	return 0;
+ }
+diff --git a/src/ap/ap_config.c b/src/ap/ap_config.c
+index 1c229c6c7..74d1e2a52 100644
+--- a/src/ap/ap_config.c
++++ b/src/ap/ap_config.c
+@@ -279,6 +279,8 @@ struct hostapd_config * hostapd_config_defaults(void)
+ 	conf->he_6ghz_max_ampdu_len_exp = 7;
+ 	conf->he_6ghz_rx_ant_pat = 1;
+ 	conf->he_6ghz_tx_ant_pat = 1;
++	conf->reg_def_cli_eirp = -1;
++	conf->he_2ghz_40mhz_width_allowed = 1;
+ #endif /* CONFIG_IEEE80211AX */
+ 
+ 	/* The third octet of the country string uses an ASCII space character
+@@ -537,7 +539,7 @@ int hostapd_setup_wpa_psk(struct hostapd_bss_config *conf)
+ }
+ 
+ 
+-static void hostapd_config_free_radius(struct hostapd_radius_server *servers,
++void hostapd_config_free_radius(struct hostapd_radius_server *servers,
+ 				       int num_servers)
+ {
+ 	int i;
+@@ -665,7 +667,7 @@ void hostapd_config_free_eap_users(struct hostapd_eap_user *user)
+ 
+ 
+ #ifdef CONFIG_WEP
+-static void hostapd_config_free_wep(struct hostapd_wep_keys *keys)
++void hostapd_config_free_wep(struct hostapd_wep_keys *keys)
+ {
+ 	int i;
+ 	for (i = 0; i < NUM_WEP_KEYS; i++) {
+diff --git a/src/ap/ap_config.h b/src/ap/ap_config.h
+index 805ea93df..676c02474 100644
+--- a/src/ap/ap_config.h
++++ b/src/ap/ap_config.h
+@@ -297,6 +297,11 @@ struct hostapd_bss_config {
+ 	unsigned int chan_util_avg_period;
+ 
+ 	int ieee802_1x; /* use IEEE 802.1X */
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++        int rdk_greylist; /* Whether greylist is enabled */
++        int ap_vlan; /* vlan id */
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
++	int min_adv_mcs; //MBR
+ 	int eapol_version;
+ 	int eap_server; /* Use internal EAP server instead of external
+ 			 * RADIUS server */
+@@ -659,6 +664,7 @@ struct hostapd_bss_config {
+ 
+ 	u8 wps_rf_bands; /* RF bands for WPS (WPS_RF_*) */
+ 
++	int connected_building_avp;
+ #ifdef CONFIG_RADIUS_TEST
+ 	char *dump_msk_file;
+ #endif /* CONFIG_RADIUS_TEST */
+@@ -785,6 +791,15 @@ struct hostapd_bss_config {
+ #define FRONTHAUL_BSS 2
+ 	int multi_ap; /* bitmap of BACKHAUL_BSS, FRONTHAUL_BSS */
+ 
++#ifdef CONFIG_DRIVER_BRCM_MAP
++        u8 map;
++        u8 map_bh_ssid[SSID_MAX_LEN];
++        size_t map_bh_ssid_len;
++        u16 map_bh_auth;
++        u16 map_bh_encr;
++        u8 map_bh_psk[PMK_LEN_MAX];
++        size_t map_bh_psk_len;
++#endif  /* CONFIG_DRIVER_BRCM_MAP */
+ #ifdef CONFIG_AIRTIME_POLICY
+ 	unsigned int airtime_weight;
+ 	int airtime_limit;
+@@ -913,6 +928,9 @@ struct hostapd_bss_config {
+ 	u8 ext_capa[EXT_CAPA_MAX_LEN];
+ 
+ 	u8 rnr;
++#ifdef CONFIG_DRIVER_BRCM
++	int spp_amsdu;
++#endif /* CONFIG_DRIVER_BRCM */
+ };
+ 
+ /**
+@@ -937,6 +955,8 @@ struct he_operation {
+ 	u16 he_rts_threshold;
+ 	u8 he_er_su_disable;
+ 	u16 he_basic_mcs_nss_set;
++	u8 he_cohosted_bss;
++	u8 he_max_cohosted_bssid;
+ };
+ 
+ /**
+@@ -1052,6 +1072,9 @@ struct hostapd_config {
+ 	u8 vht_oper_centr_freq_seg0_idx;
+ 	u8 vht_oper_centr_freq_seg1_idx;
+ 	u8 ht40_plus_minus_allowed;
++        u8 ht_rifs;
++
++	u16 vht_oper_basic_mcs_set;
+ 
+ 	/* Use driver-generated interface addresses when adding multiple BSSs */
+ 	u8 use_driver_iface_addr;
+@@ -1100,6 +1123,15 @@ struct hostapd_config {
+ 	u8 he_6ghz_rx_ant_pat;
+ 	u8 he_6ghz_tx_ant_pat;
+ 	u8 he_6ghz_reg_pwr_type;
++	/*
++	 * This value should be used when regulatory client EIRP PSD values
++	 * advertised by an AP that is an SP AP or an indoor SP AP are
++	 * insufficient to ensure that regulatory client limits on total EIRP
++	 * are always met for all transmission bandwidths within the bandwidth
++	 * of the AP’s BSS.
++	 */
++	int reg_def_cli_eirp;
++	u8 he_2ghz_40mhz_width_allowed;
+ #endif /* CONFIG_IEEE80211AX */
+ 
+ 	/* VHT enable/disable config from CHAN_SWITCH */
+@@ -1127,7 +1159,9 @@ struct hostapd_config {
+ 	unsigned int airtime_update_interval;
+ #define AIRTIME_MODE_MAX (__AIRTIME_MODE_MAX - 1)
+ #endif /* CONFIG_AIRTIME_POLICY */
+-
++#ifdef CONFIG_DRIVER_BRCM
++	int ft_rrb_lo_sock; /* Create loopback socket for FT RRB OUI */
++#endif /* CONFIG_DRIVER_BRCM */
+ 	int ieee80211be;
+ #ifdef CONFIG_IEEE80211BE
+ 	u8 eht_oper_chwidth;
+diff --git a/src/ap/ap_drv_ops.c b/src/ap/ap_drv_ops.c
+index 8af7a0e25..408e7aaf8 100644
+--- a/src/ap/ap_drv_ops.c
++++ b/src/ap/ap_drv_ops.c
+@@ -84,7 +84,11 @@ int hostapd_build_ap_extra_ies(struct hostapd_data *hapd,
+ 		goto fail;
+ 
+ 	pos = buf;
++
++/* avoid duplicated extended cap tag in beacon */
++#ifndef CONFIG_DRIVER_BRCM
+ 	pos = hostapd_eid_ext_capab(hapd, pos);
++#endif
+ 	if (add_buf_data(&assocresp, buf, pos - buf) < 0)
+ 		goto fail;
+ 	pos = hostapd_eid_interworking(hapd, pos);
+@@ -112,9 +116,15 @@ int hostapd_build_ap_extra_ies(struct hostapd_data *hapd,
+ 	if (add_buf_data(&assocresp, buf, pos - buf) < 0)
+ 		goto fail;
+ 
++/* avoid duplicated WPS tag in beacon */
++#ifndef CONFIG_DRIVER_BRCM
+ 	if (add_buf(&beacon, hapd->wps_beacon_ie) < 0 ||
+ 	    add_buf(&proberesp, hapd->wps_probe_resp_ie) < 0)
+ 		goto fail;
++#else
++	if (add_buf(&proberesp, hapd->wps_probe_resp_ie) < 0)
++		goto fail;
++#endif
+ 
+ #ifdef CONFIG_P2P
+ 	if (add_buf(&beacon, hapd->p2p_beacon_ie) < 0 ||
+@@ -256,6 +266,17 @@ int hostapd_set_ap_wps_ie(struct hostapd_data *hapd)
+ 	return ret;
+ }
+ 
++#ifdef RDK_ONEWIFI
++int hostapd_drv_wps_event_notify_cb(struct hostapd_data *hapd, enum wps_event event,
++                                    union wps_event_data *data)
++{
++	if (!hapd->driver || !hapd->driver->wps_event_notify_cb || !hapd->drv_priv) {
++		return 0;
++	}
++
++	return hapd->driver->wps_event_notify_cb(hapd->drv_priv, event, (union wps_event_data *)data);
++}
++#endif //RDK_ONEWIFI
+ 
+ int hostapd_set_authorized(struct hostapd_data *hapd,
+ 			   struct sta_info *sta, int authorized)
+@@ -742,6 +763,22 @@ int hostapd_drv_sta_deauth(struct hostapd_data *hapd,
+ 					reason);
+ }
+ 
++int hostapd_drv_radius_eap_failure(struct hostapd_data *hapd,
++                           int failure_reason)
++{
++       if (!hapd->driver || !hapd->driver->radius_eap_failure || !hapd->drv_priv)
++               return 0;
++       return hapd->driver->radius_eap_failure(hapd->drv_priv, failure_reason);
++}
++
++int hostapd_drv_sta_notify_deauth(struct hostapd_data *hapd,
++			   const u8 *addr, int reason)
++{
++	if (!hapd->driver || !hapd->driver->sta_notify_deauth || !hapd->drv_priv)
++		return 0;
++	return hapd->driver->sta_notify_deauth(hapd->drv_priv, hapd->own_addr, addr,
++					reason);
++}
+ 
+ int hostapd_drv_sta_disassoc(struct hostapd_data *hapd,
+ 			     const u8 *addr, int reason)
+@@ -1013,3 +1050,21 @@ int hostapd_drv_dpp_listen(struct hostapd_data *hapd, bool enable)
+ 		return 0;
+ 	return hapd->driver->dpp_listen(hapd->drv_priv, enable);
+ }
++
++size_t hostapd_drv_eid_rnr_colocation_len(struct hostapd_data *hapd,
++				       size_t *current_len)
++{
++	if (!hapd->driver || !hapd->driver->get_rnr_colocation_len || !hapd->drv_priv)
++		return 0;
++
++	return hapd->driver->get_rnr_colocation_len(hapd->drv_priv, current_len);
++}
++
++u8* hostapd_drv_eid_rnr_colocation(struct hostapd_data *hapd, u8 *eid,
++				      size_t *current_len)
++{
++	if (!hapd->driver || !hapd->driver->get_rnr_colocation_ie || !hapd->drv_priv)
++		return eid;
++
++	return hapd->driver->get_rnr_colocation_ie(hapd->drv_priv, eid, current_len);
++}
+diff --git a/src/ap/ap_drv_ops.h b/src/ap/ap_drv_ops.h
+index b4fb766ee..22ca403da 100644
+--- a/src/ap/ap_drv_ops.h
++++ b/src/ap/ap_drv_ops.h
+@@ -26,6 +26,10 @@ void hostapd_free_ap_extra_ies(struct hostapd_data *hapd, struct wpabuf *beacon,
+ 			       struct wpabuf *assocresp);
+ int hostapd_reset_ap_wps_ie(struct hostapd_data *hapd);
+ int hostapd_set_ap_wps_ie(struct hostapd_data *hapd);
++#ifdef RDK_ONEWIFI
++int hostapd_drv_wps_event_notify_cb(struct hostapd_data *hapd, enum wps_event event,
++				    union wps_event_data *data);
++#endif //RDK_ONEWIFI
+ int hostapd_set_authorized(struct hostapd_data *hapd,
+ 			   struct sta_info *sta, int authorized);
+ int hostapd_set_sta_flags(struct hostapd_data *hapd, struct sta_info *sta);
+@@ -102,6 +106,9 @@ int hostapd_drv_send_mlme(struct hostapd_data *hapd,
+ 			  int no_encrypt);
+ int hostapd_drv_sta_deauth(struct hostapd_data *hapd,
+ 			   const u8 *addr, int reason);
++int hostapd_drv_radius_eap_failure(struct hostapd_data *hapd, int failure_reason);
++int hostapd_drv_sta_notify_deauth(struct hostapd_data *hapd,
++			   const u8 *addr, int reason);
+ int hostapd_drv_sta_disassoc(struct hostapd_data *hapd,
+ 			     const u8 *addr, int reason);
+ int hostapd_drv_send_action(struct hostapd_data *hapd, unsigned int freq,
+@@ -138,7 +145,10 @@ int hostapd_drv_do_acs(struct hostapd_data *hapd);
+ int hostapd_drv_update_dh_ie(struct hostapd_data *hapd, const u8 *peer,
+ 			     u16 reason_code, const u8 *ie, size_t ielen);
+ int hostapd_drv_dpp_listen(struct hostapd_data *hapd, bool enable);
+-
++size_t hostapd_drv_eid_rnr_colocation_len(struct hostapd_data *hapd,
++				       size_t *current_len);
++u8* hostapd_drv_eid_rnr_colocation(struct hostapd_data *hapd, u8 *eid,
++				   size_t *current_len);
+ 
+ #include "drivers/driver.h"
+ 
+@@ -430,4 +440,13 @@ hostapd_drv_register_frame(struct hostapd_data *hapd, u16 type,
+ }
+ #endif /* CONFIG_TESTING_OPTIONS */
+ 
++#ifdef CONFIG_DRIVER_BRCM
++static inline int
++hostapd_drv_stop_bss(struct hostapd_data *hapd)
++{
++	if (!hapd->driver || !hapd->driver->stop_bss || !hapd->drv_priv)
++		return 0;
++	return hapd->driver->stop_bss(hapd->drv_priv);
++}
++#endif /* CONFIG_DRIVER_BRCM */
+ #endif /* AP_DRV_OPS */
+diff --git a/src/ap/beacon.c b/src/ap/beacon.c
+index eaa403326..4e4910ee1 100644
+--- a/src/ap/beacon.c
++++ b/src/ap/beacon.c
+@@ -124,13 +124,13 @@ static u8 * hostapd_eid_pwr_constraint(struct hostapd_data *hapd, u8 *eid)
+ 	u8 local_pwr_constraint = 0;
+ 	int dfs;
+ 
+-	if (hapd->iface->current_mode == NULL ||
+-	    hapd->iface->current_mode->mode != HOSTAPD_MODE_IEEE80211A)
++	if (hapd->iface->current_mode == NULL /*||
++	    hapd->iface->current_mode->mode != HOSTAPD_MODE_IEEE80211A*/)
+ 		return eid;
+ 
+ 	/* Let host drivers add this IE if DFS support is offloaded */
+-	if (hapd->iface->drv_flags & WPA_DRIVER_FLAGS_DFS_OFFLOAD)
+-		return eid;
++	/*if (hapd->iface->drv_flags & WPA_DRIVER_FLAGS_DFS_OFFLOAD)
++		return eid;*/
+ 
+ 	/*
+ 	 * There is no DFS support and power constraint was not directly
+@@ -352,6 +352,19 @@ static u8 * hostapd_get_mde(struct hostapd_data *hapd, u8 *pos, size_t len)
+ 	return pos + 2 + ie[1];
+ }
+ 
++#ifdef CONFIG_DRIVER_BRCM
++static u8 * hostapd_get_fte(struct hostapd_data *hapd, u8 *pos, size_t len)
++{
++	const u8 *ie;
++
++	ie = hostapd_wpa_ie(hapd, WLAN_EID_FAST_BSS_TRANSITION);
++	if (!ie || 2U + ie[1] > len)
++		return pos;
++
++	os_memcpy(pos, ie, 2 + ie[1]);
++	return pos + 2 + ie[1];
++}
++#endif /* CONFIG_DRIVER_BRCM */
+ 
+ static u8 * hostapd_get_rsnxe(struct hostapd_data *hapd, u8 *pos, size_t len)
+ {
+@@ -436,7 +449,9 @@ static u8 * hostapd_eid_ecsa(struct hostapd_data *hapd, u8 *eid)
+ 
+ static u8 * hostapd_eid_supported_op_classes(struct hostapd_data *hapd, u8 *eid)
+ {
+-	u8 op_class, channel;
++	u8 *eid_len;
++	u8 op_class, channel, op_classes[32];
++	struct hostapd_hw_modes *mode;
+ 
+ 	if (!(hapd->iface->drv_flags & WPA_DRIVER_FLAGS_AP_CSA) ||
+ 	    !hapd->iface->freq)
+@@ -450,13 +465,40 @@ static u8 * hostapd_eid_supported_op_classes(struct hostapd_data *hapd, u8 *eid)
+ 		return eid;
+ 
+ 	*eid++ = WLAN_EID_SUPPORTED_OPERATING_CLASSES;
+-	*eid++ = 2;
++	eid_len = eid++;
++	*eid_len = 1;
+ 
+ 	/* Current Operating Class */
+ 	*eid++ = op_class;
+ 
+-	/* TODO: Advertise all the supported operating classes */
+-	*eid++ = 0;
++	mode = hapd->iface->current_mode;
++	memset(op_classes, 0, sizeof(op_classes));
++
++	for (unsigned int width = 0; width <= hostapd_get_oper_chwidth(hapd->iconf); width++) {
++		for (int ch = 0; ch < mode->num_channels; ch++) {
++			struct hostapd_channel_data *chan = &mode->channels[ch];
++			if (chan->flag & HOSTAPD_CHAN_DISABLED)
++				continue;
++
++			for (int sec_chan = -1; sec_chan <= 1; sec_chan++) {
++				if (ieee80211_freq_to_channel_ext(chan->freq,
++								  sec_chan,
++								  width,
++								  &op_class,
++								  &channel) !=
++				    NUM_HOSTAPD_MODES) {
++					op_classes[op_class / 8] |= 1 << (op_class % 8);
++				}
++			}
++		}
++	}
++
++	for (unsigned int i = 0; i < sizeof(op_classes) * 8; i++) {
++		if (op_classes[i / 8] & (1 << (i % 8))) {
++			*eid++ = i;
++			(*eid_len)++;
++		}
++	}
+ 
+ 	return eid;
+ }
+@@ -505,6 +547,12 @@ static u8 * hostapd_gen_probe_resp(struct hostapd_data *hapd,
+ 			if (hapd->iconf->he_6ghz_reg_pwr_type ==
+ 			    HE_6GHZ_INDOOR_AP)
+ 				buflen += 4;
++
++			/* An additional Transmit Power Envelope element for
++			 * default client with unit interpretation of regulatory
++			 * client EIRP */
++			if (hapd->iconf->reg_def_cli_eirp != -1)
++				buflen += 4;
+ 		}
+ 	}
+ #endif /* CONFIG_IEEE80211AX */
+@@ -1388,6 +1436,12 @@ static u8 * hostapd_gen_fils_discovery(struct hostapd_data *hapd, size_t *len)
+ 		total_len += 4;
+ 		if (hapd->iconf->he_6ghz_reg_pwr_type == HE_6GHZ_INDOOR_AP)
+ 			total_len += 4;
++
++		/* An additional Transmit Power Envelope element for
++		 * default client with unit interpretation of regulatory
++		 * client EIRP */
++		if (hapd->iconf->reg_def_cli_eirp != -1)
++			total_len += 4;
+ 	}
+ #endif /* CONFIG_IEEE80211AX */
+ 
+@@ -1548,6 +1602,12 @@ int ieee802_11_build_ap_params(struct hostapd_data *hapd,
+ 			if (hapd->iconf->he_6ghz_reg_pwr_type ==
+ 			    HE_6GHZ_INDOOR_AP)
+ 				tail_len += 4;
++
++			/* An additional Transmit Power Envelope element for
++			 * default client with unit interpretation of regulatory
++			 * client EIRP */
++			if (hapd->iconf->reg_def_cli_eirp != -1)
++				tail_len += 4;
+ 		}
+ 	}
+ #endif /* CONFIG_IEEE80211AX */
+@@ -1634,6 +1694,9 @@ int ieee802_11_build_ap_params(struct hostapd_data *hapd,
+ 	tailpos = hostapd_eid_rm_enabled_capab(hapd, tailpos,
+ 					       tailend - tailpos);
+ 	tailpos = hostapd_get_mde(hapd, tailpos, tailend - tailpos);
++#ifdef CONFIG_DRIVER_BRCM
++	tailpos = hostapd_get_fte(hapd, tailpos, tailend - tailpos);
++#endif /* CONFIG_DRIVER_BRCM */
+ 
+ 	/* eCSA IE */
+ 	csa_pos = hostapd_eid_ecsa(hapd, tailpos);
+diff --git a/src/ap/ctrl_iface_ap.c b/src/ap/ctrl_iface_ap.c
+index 29b41f5bc..c8742f44c 100644
+--- a/src/ap/ctrl_iface_ap.c
++++ b/src/ap/ctrl_iface_ap.c
+@@ -25,7 +25,9 @@
+ #include "mbo_ap.h"
+ #include "taxonomy.h"
+ #include "wnm_ap.h"
+-
++#ifdef CONFIG_DRIVER_BRCM
++#include "beacon.h"
++#endif /* CONFIG_DRIVER_BRCM */
+ 
+ static size_t hostapd_write_ht_mcs_bitmask(char *buf, size_t buflen,
+ 					   size_t curr_len, const u8 *mcs_set)
+@@ -1065,7 +1067,26 @@ void * hostapd_ctrl_iface_pmksa_create_entry(const u8 *aa, char *cmd)
+ 
+ #endif /* CONFIG_MESH */
+ #endif /* CONFIG_PMKSA_CACHE_EXTERNAL */
++#ifdef CONFIG_DRIVER_BRCM
++int hostapd_ctrl_iface_start_bss(struct hostapd_data *hapd)
++{
++	hapd->bss_started = 1;
++
++	wpa_printf(MSG_INFO, " %s: start BSS", (hapd->conf ? hapd->conf->iface : "NA"));
++
++	hapd->reenable_beacon = 1;
++	return ieee802_11_set_beacon(hapd);
++}
+ 
++int hostapd_ctrl_iface_stop_bss(struct hostapd_data *hapd)
++{
++	hapd->bss_started = 0;
++
++	wpa_printf(MSG_INFO, "%s: stop BSS", (hapd->conf ? hapd->conf->iface : "NA"));
++
++	return hostapd_drv_stop_bss(hapd);
++}
++#endif /* CONFIG_DRIVER_BRCM */
+ 
+ #ifdef CONFIG_WNM_AP
+ 
+diff --git a/src/ap/ctrl_iface_ap.h b/src/ap/ctrl_iface_ap.h
+index 614f0426c..b3b730010 100644
+--- a/src/ap/ctrl_iface_ap.h
++++ b/src/ap/ctrl_iface_ap.h
+@@ -36,7 +36,10 @@ int hostapd_ctrl_iface_pmksa_add(struct hostapd_data *hapd, char *cmd);
+ int hostapd_ctrl_iface_pmksa_list_mesh(struct hostapd_data *hapd,
+ 				       const u8 *addr, char *buf, size_t len);
+ void * hostapd_ctrl_iface_pmksa_create_entry(const u8 *aa, char *cmd);
+-
++#ifdef CONFIG_DRIVER_BRCM
++int hostapd_ctrl_iface_start_bss(struct hostapd_data *hapd);
++int hostapd_ctrl_iface_stop_bss(struct hostapd_data *hapd);
++#endif /* CONFIG_DRIVER_BRCM */
+ int hostapd_ctrl_iface_disassoc_imminent(struct hostapd_data *hapd,
+ 					 const char *cmd);
+ int hostapd_ctrl_iface_ess_disassoc(struct hostapd_data *hapd,
+diff --git a/src/ap/dfs.c b/src/ap/dfs.c
+index e46dd7ede..de86407da 100644
+--- a/src/ap/dfs.c
++++ b/src/ap/dfs.c
+@@ -19,12 +19,6 @@
+ #include "dfs.h"
+ 
+ 
+-enum dfs_channel_type {
+-	DFS_ANY_CHANNEL,
+-	DFS_AVAILABLE, /* non-radar or radar-available */
+-	DFS_NO_CAC_YET, /* radar-not-yet-available */
+-};
+-
+ static struct hostapd_channel_data *
+ dfs_downgrade_bandwidth(struct hostapd_iface *iface, int *secondary_channel,
+ 			u8 *oper_centr_freq_seg0_idx,
+@@ -154,7 +148,7 @@ static int dfs_is_chan_allowed(struct hostapd_channel_data *chan, int n_chans)
+ }
+ 
+ 
+-static struct hostapd_channel_data *
++struct hostapd_channel_data *
+ dfs_get_chan_data(struct hostapd_hw_modes *mode, int freq, int first_chan_idx)
+ {
+ 	int i;
+@@ -502,7 +496,7 @@ static int dfs_check_chans_unavailable(struct hostapd_iface *iface,
+ }
+ 
+ 
+-static struct hostapd_channel_data *
++struct hostapd_channel_data *
+ dfs_get_valid_channel(struct hostapd_iface *iface,
+ 		      int *secondary_channel,
+ 		      u8 *oper_centr_freq_seg0_idx,
+@@ -624,7 +618,7 @@ static int dfs_set_valid_channel(struct hostapd_iface *iface, int skip_radar)
+ }
+ 
+ 
+-static int set_dfs_state_freq(struct hostapd_iface *iface, int freq, u32 state)
++int set_dfs_state_freq(struct hostapd_iface *iface, int freq, u32 state)
+ {
+ 	struct hostapd_hw_modes *mode;
+ 	struct hostapd_channel_data *chan = NULL;
+@@ -649,8 +643,7 @@ static int set_dfs_state_freq(struct hostapd_iface *iface, int freq, u32 state)
+ 	return 0;
+ }
+ 
+-
+-static int set_dfs_state(struct hostapd_iface *iface, int freq, int ht_enabled,
++int set_dfs_state(struct hostapd_iface *iface, int freq, int ht_enabled,
+ 			 int chan_offset, int chan_width, int cf1,
+ 			 int cf2, u32 state)
+ {
+@@ -716,7 +709,7 @@ static int set_dfs_state(struct hostapd_iface *iface, int freq, int ht_enabled,
+ }
+ 
+ 
+-static int dfs_are_channels_overlapped(struct hostapd_iface *iface, int freq,
++int dfs_are_channels_overlapped(struct hostapd_iface *iface, int freq,
+ 				       int chan_width, int cf1, int cf2)
+ {
+ 	int start_chan_idx, start_chan_idx1;
+@@ -1082,7 +1075,7 @@ static void hostpad_dfs_update_background_chain(struct hostapd_iface *iface)
+ }
+ 
+ 
+-static bool
++bool
+ hostapd_dfs_is_background_event(struct hostapd_iface *iface, int freq)
+ {
+ 	return dfs_use_radar_background(iface) &&
+diff --git a/src/ap/dfs.h b/src/ap/dfs.h
+index 606c1b393..f737367a4 100644
+--- a/src/ap/dfs.h
++++ b/src/ap/dfs.h
+@@ -9,6 +9,12 @@
+ #ifndef DFS_H
+ #define DFS_H
+ 
++enum dfs_channel_type {
++	DFS_ANY_CHANNEL,
++	DFS_AVAILABLE, /* non-radar or radar-available */
++	DFS_NO_CAC_YET, /* radar-not-yet-available */
++};
++
+ int hostapd_handle_dfs(struct hostapd_iface *iface);
+ 
+ int hostapd_dfs_complete_cac(struct hostapd_iface *iface, int success, int freq,
+@@ -32,5 +38,10 @@ int hostapd_dfs_start_cac(struct hostapd_iface *iface, int freq,
+ int hostapd_handle_dfs_offload(struct hostapd_iface *iface);
+ int hostapd_is_dfs_overlap(struct hostapd_iface *iface, enum chan_width width,
+ 			   int center_freq);
++struct hostapd_channel_data *dfs_get_valid_channel(struct hostapd_iface *iface, int *secondary_channel, u8 *oper_centr_freq_seg0_idx, u8 *oper_centr_freq_seg1_idx, enum dfs_channel_type type);
++int set_dfs_state(struct hostapd_iface *iface, int freq, int ht_enabled, int chan_offset, int chan_width, int cf1, int cf2, u32 state);
++bool hostapd_dfs_is_background_event(struct hostapd_iface *iface, int freq);
++int dfs_are_channels_overlapped(struct hostapd_iface *iface, int freq, int chan_width, int cf1, int cf2);
++struct hostapd_channel_data *dfs_get_chan_data(struct hostapd_hw_modes *mode, int freq, int first_chan_idx);
+ 
+ #endif /* DFS_H */
+diff --git a/src/ap/drv_callbacks.c b/src/ap/drv_callbacks.c
+index 6c1e61137..9fdf87b76 100644
+--- a/src/ap/drv_callbacks.c
++++ b/src/ap/drv_callbacks.c
+@@ -764,10 +764,17 @@ void hostapd_notif_disassoc(struct hostapd_data *hapd, const u8 *addr)
+ 
+ 	ap_sta_set_authorized(hapd, sta, 0);
+ 	sta->flags &= ~(WLAN_STA_AUTH | WLAN_STA_ASSOC);
++#ifdef CONFIG_DRIVER_BRCM
++	/* This disassoc notification is due to driver event */
++	sta->flags |= WLAN_STA_DRIVER_IND;
++#endif /* CONFIG_DRIVER_BRCM */
+ 	hostapd_set_sta_flags(hapd, sta);
+ 	wpa_auth_sm_event(sta->wpa_sm, WPA_DISASSOC);
+ 	sta->acct_terminate_cause = RADIUS_ACCT_TERMINATE_CAUSE_USER_REQUEST;
+ 	ieee802_1x_notify_port_enabled(sta->eapol_sm, 0);
++#ifdef _PLATFORM_RASPBERRYPI_
++	hostapd_drv_sta_disassoc(hapd, sta->addr, WLAN_REASON_DISASSOC_STA_HAS_LEFT);
++#endif
+ 	ap_free_sta(hapd, sta);
+ }
+ 
+@@ -1207,7 +1214,7 @@ int hostapd_probe_req_rx(struct hostapd_data *hapd, const u8 *sa, const u8 *da,
+ #ifdef HOSTAPD
+ 
+ #ifdef CONFIG_IEEE80211R_AP
+-static void hostapd_notify_auth_ft_finish(void *ctx, const u8 *dst,
++void hostapd_notify_auth_ft_finish(void *ctx, const u8 *dst,
+ 					  const u8 *bssid,
+ 					  u16 auth_transaction, u16 status,
+ 					  const u8 *ies, size_t ies_len)
+@@ -1254,7 +1261,7 @@ static void hostapd_notify_auth_fils_finish(struct hostapd_data *hapd,
+ #endif /* CONFIG_FILS */
+ 
+ 
+-static void hostapd_notif_auth(struct hostapd_data *hapd,
++void hostapd_notif_auth(struct hostapd_data *hapd,
+ 			       struct auth_info *rx_auth)
+ {
+ 	struct sta_info *sta;
+@@ -1891,6 +1898,9 @@ void wpa_supplicant_event(void *ctx, enum wpa_event_type event,
+ 	case EVENT_WPS_BUTTON_PUSHED:
+ 		hostapd_wps_button_pushed(hapd, NULL);
+ 		break;
++	case EVENT_WPS_CANCEL:
++		hostapd_wps_cancel(hapd);
++		break;
+ #ifdef NEED_AP_MLME
+ 	case EVENT_TX_STATUS:
+ 		switch (data->tx_status.type) {
+@@ -2093,6 +2103,14 @@ void wpa_supplicant_event(void *ctx, enum wpa_event_type event,
+ 			data->wds_sta_interface.ifname,
+ 			data->wds_sta_interface.sta_addr);
+ 		break;
++#if defined(CONFIG_DRIVER_BRCM) && defined(CONFIG_WPS_UPNP)
++	case EVENT_INTERFACE_IP_ADDR_CHANGED:
++		if (hapd->conf->upnp_iface &&
++			!os_strcmp(hapd->conf->upnp_iface, data->interface_status.ifname)) {
++			hostapd_wps_upnp_ifcae_ip_changed(hapd);
++		}
++		break;
++#endif	/* CONFIG_DRIVER_BRCM && CONFIG_WPS_UPNP */
+ #ifdef CONFIG_IEEE80211AX
+ 	case EVENT_BSS_COLOR_COLLISION:
+ 		/* The BSS color is shared amongst all BBSs on a specific phy.
+diff --git a/src/ap/gas_serv.c b/src/ap/gas_serv.c
+index 90f15778b..408d704e0 100644
+--- a/src/ap/gas_serv.c
++++ b/src/ap/gas_serv.c
+@@ -19,7 +19,9 @@
+ #include "dpp_hostapd.h"
+ #include "sta_info.h"
+ #include "gas_serv.h"
+-
++#ifdef CONFIG_DRIVER_BRCM
++#include "common/dpp.h"
++#endif /* CONFIG_DRIVER_BRCM */
+ 
+ #ifdef CONFIG_DPP
+ static void gas_serv_write_dpp_adv_proto(struct wpabuf *buf)
+@@ -1527,6 +1529,9 @@ void gas_serv_req_dpp_processing(struct hostapd_data *hapd,
+ 				 int prot, struct wpabuf *buf)
+ {
+ 	struct wpabuf *tx_buf;
++#ifdef CONFIG_DRIVER_BRCM
++	unsigned int freq = hapd->dpp_auth->curr_freq;
++#endif /* CONFIG_DRIVER_BRCM */
+ 
+ 	if (wpabuf_len(buf) > hapd->conf->gas_frag_limit ||
+ 	    hapd->conf->gas_comeback_delay) {
+@@ -1582,9 +1587,17 @@ void gas_serv_req_dpp_processing(struct hostapd_data *hapd,
+ 		return;
+ 	if (prot)
+ 		convert_to_protected_dual(tx_buf);
++#ifdef CONFIG_DRIVER_BRCM
++	wpa_printf(MSG_DEBUG,
++		   "DPP: sending action frame in listen channel\n");
++	hostapd_drv_send_action(hapd, freq, 0, sa,
++				wpabuf_head(tx_buf),
++				wpabuf_len(tx_buf));
++#else
+ 	hostapd_drv_send_action(hapd, hapd->iface->freq, 0, sa,
+ 				wpabuf_head(tx_buf),
+ 				wpabuf_len(tx_buf));
++#endif /* CONFIG_DRIVER_BRCM */
+ 	wpabuf_free(tx_buf);
+ }
+ #endif /* CONFIG_DPP */
+diff --git a/src/ap/greylist.c b/src/ap/greylist.c
+new file mode 100644
+index 000000000..e694a048d
+--- /dev/null
++++ b/src/ap/greylist.c
+@@ -0,0 +1,766 @@
++/*
++ * hostapd / RADIUS Greylist Access Control
++ *
++ * RadiusGreylist is the feature controlled by RFC
++ * this feature will add the clients mac to public vaps maclist,
++ * which  are connected to public vaps from their own device.
++ * Greylist implementations and  definations are added here.
++ *
++ *
++ *
++ */
++
++#define __USE_XOPEN
++#define _GNU_SOURCE
++#include <time.h>
++#include <sys/file.h>
++#include <sys/stat.h>
++#include <sys/types.h>
++#include <unistd.h>
++#include <string.h>
++#include "utils/includes.h"
++#include "utils/common.h"
++#include "utils/eloop.h"
++#include "greylist.h"
++
++/* Timeout value from the client association time for deleting the
++ * mac entry from greylist_mac.txt, and deleting the mac from access
++ * control list of all greylist enabled vaps. */
++#define GREYLIST_TIMEOUT_IN_SECONDS (24 * 60 * 60)
++
++#define GREYLIST_MAX_NUM_OF_RECORDS 128
++
++struct greylist_data {
++	struct hapd_interfaces *interfaces;
++	char txtaddr[TXT_MAC_ADDR_LEN];
++};
++
++/* Global array that stores CM mac of the gateway. */
++char cmmac[TXT_MAC_ADDR_LEN];
++
++static const char *wifi_health_log = "/rdklogs/logs/wifihealth.txt";
++static const char *greylist_file = "/nvram/greylist_mac.txt";
++
++static void greylist_log_to_file(char *fmt, ...);
++int greylist_get_cmmac();
++static size_t greylist_delete_line(char *buffer, size_t size, const char *txtaddr);
++static void greylist_delete_from_file(struct hapd_interfaces *interfaces, const char *txtaddr);
++static void greylist_timeout(void *eloop_ctx, void *timeout_ctx);
++static void greylist_add_to_driver(struct hapd_interfaces *interfaces, const char *txtaddr);
++static int greylist_add_to_other_hostapd(const char *txtaddr);
++
++
++/**
++ * greylist_get_vap_index - Get RDK specific vap index of the given interface
++ */
++static int greylist_get_vap_index(const char* ifname)
++{
++   char str[IFNAMSIZ + 1];
++   char *p;
++   int unit = -1, subunit = -1;
++   size_t ifname_len, len;
++   unsigned long val;
++
++   if (!ifname || *ifname == '\0')
++       return -1;
++
++   ifname_len = strlen(ifname);
++   if (ifname_len + 1 > sizeof(str))
++       return -1;
++
++   strcpy(str, ifname);
++   p = str + ifname_len - 1;
++
++   /* find the trailing digit chars */
++   len = 0;
++   while (p >= str && (*p >= '0' && *p <= '9')) {
++       --p;
++       ++len;
++   }
++
++   /* fail if there are no trailing digits */
++   if (len == 0)
++       return -1;
++
++   ++p;
++   val = strtoul(p, NULL, 10);
++
++   /* if we are at the beginning of the string, or the previous
++    * character is not a '.', then we have the unit number and
++    * we are done parsing
++    */
++   if (p == str || p[-1] != '.') {
++       unit = val;
++
++       return unit + 1;
++   } else
++       subunit = val;
++
++   /* chop off the '.NNN' and get the unit number */
++   p--;
++   *p = '\0';
++   p--;
++
++   /* find the trailing digit chars */
++   len = 0;
++   while (p >= str && (*p >= '0' && *p <= '9')) {
++       --p;
++       ++len;
++   }
++
++   /* fail if there were no trailing digits */
++   if (len == 0)
++       return -1;
++
++   /* point to the beginning of the last integer and convert */
++   ++p;
++   val = strtoul(p, NULL, 10);
++
++   /* save the unit number */
++   unit = val;
++
++   return unit + subunit*2 + 1;
++}
++
++
++/**
++ * greylist_log_to_file - Add the log into wifihealth.txt for telemetry usage
++ */
++static void greylist_log_to_file(char *fmt, ...)
++{
++    FILE *fp = NULL;
++    va_list args;
++
++    fp = fopen(wifi_health_log, "a+");
++    if (fp == NULL) {
++        return;
++    }
++
++    va_start(args, fmt);
++    vfprintf(fp, fmt, args);
++    va_end(args);
++
++    fflush(fp);
++    fclose(fp);
++}
++
++
++/**
++ * greylist_get_cmmac - Call the script to get cm mac of the gateway
++ */
++int greylist_get_cmmac()
++{
++	FILE *fp;
++	const char *cmd = "/usr/sbin/deviceinfo.sh -cmac";
++
++	fp = popen(cmd, "r");
++
++	if (fp == NULL) {
++		wpa_printf(MSG_ERROR, "GREYLIST: %s: popen failed\n",
++				__func__);
++		return -1;
++	}
++
++	fgets(cmmac, sizeof(cmmac), fp);
++	pclose(fp);
++	if (*cmmac == '\0') {
++		wpa_printf(MSG_ERROR, "GREYLIST: %s: \'%s\' failed\n",
++				__func__, cmd);
++		return -1;
++	}
++	return 0;
++}
++
++
++/**
++ * greylist_delete_line - Delete the mac entry in memory
++ */
++static size_t greylist_delete_line(char *buffer, size_t size, const char *txtaddr)
++{
++	char *p = buffer, *q, *end = buffer + size;
++	char *mac_in_buf;
++
++	while (p < end) {
++		q = p;
++		while (q < end && *q != ' ') ++q; //skip date
++		++q;
++
++		while (q < end && *q != ' ') ++q; //skip time
++		if (++q >= end)
++			break;
++
++		mac_in_buf = q;
++		while (q < end && *q != '\n') ++q;
++		++q; //q now points to beginning of next line or end
++
++		if (os_memcmp(mac_in_buf, txtaddr, TXT_MAC_ADDR_LEN - 1) == 0) { //found
++			size_t line_size = q - p;
++			size_t rest_size = buffer + size -  q;
++
++			os_memmove(p, q, rest_size);
++
++			return size - line_size;
++		}
++
++		p = q;
++	}
++
++	return size;
++}
++
++
++/*
++ * greylist_delete_from_file - Delete the mac entry from /nvram/greylist_mac.txt
++ */
++static void greylist_delete_from_file(struct hapd_interfaces *interfaces, const char *txtaddr)
++{
++	struct stat st;
++	int fd;
++	char *buffer = NULL;
++	struct hostapd_iface *interface;
++	struct hostapd_bss_config *conf;
++
++	wpa_printf(MSG_DEBUG, "GREYLIST: delete %s from %s\n",
++			txtaddr, greylist_file);
++
++	interface = interfaces->iface[0];
++	conf = interface->bss[0]->conf;
++
++	fd = open(greylist_file, O_RDWR);
++	if (fd < 0) {
++		wpa_printf(MSG_ERROR, "GREYLIST: %s: fail to open %s\n",
++				__func__, greylist_file);
++		return;
++	}
++
++	if (fstat(fd, &st) != 0) {
++		wpa_printf(MSG_ERROR, "GREYLIST: %s: fail to get size of %s\n",
++				__func__, greylist_file);
++		close(fd);
++		return;
++	}
++
++	buffer = os_malloc(st.st_size);
++	if (!buffer) {
++		wpa_printf(MSG_ERROR,
++				"GREYLIST: %s: fail to allocate buffer\n", __func__);
++		close(fd);
++		return;
++	}
++
++	wpa_printf(MSG_DEBUG, "GREYLIST: %s: %s: trying to get file lock\n",
++			__func__, conf->iface);
++	flock(fd, LOCK_EX);
++	wpa_printf(MSG_DEBUG, "GREYLIST: %s: %s: got file lock\n",
++			__func__, conf->iface);
++	if (read(fd, buffer, st.st_size) == st.st_size) {
++		size_t new_size;
++
++		new_size = greylist_delete_line(buffer, st.st_size, txtaddr);
++
++		if (ftruncate(fd, 0) == 0) {
++			if (write(fd, buffer, new_size) != new_size) {
++				wpa_printf(MSG_ERROR,
++						"GREYLIST: %s: fail to write to %s\n",
++						__func__, greylist_file);
++			}
++		}
++		else {
++			wpa_printf(MSG_ERROR,
++					"GREYLIST: %s: fail to truncate %s\n",
++					__func__, greylist_file);
++		}
++	}
++	else {
++		wpa_printf(MSG_ERROR, "GREYLIST: %s: fail to read %s\n",
++				__func__, greylist_file);
++	}
++
++	flock(fd, LOCK_UN);
++	wpa_printf(MSG_DEBUG, "GREYLIST: %s: %s: released file lock\n",
++			__func__, conf->iface);
++	close(fd);
++	os_free(buffer);
++}
++
++
++/**
++ * greylist_timeout - Timeout handler to remove client's mac from greylist
++ *
++ * The function is used to delete the mac entry from greylist_mac.txt and
++ * delete the mac from access control list of all greylist enabled vaps.
++ */
++static void greylist_timeout(void *eloop_ctx, void *timeout_ctx)
++{
++	struct greylist_data *data = eloop_ctx;
++	struct hapd_interfaces *interfaces;
++	struct hostapd_iface *interface;
++	struct hostapd_bss_config *conf;
++	size_t i, j;
++	char cmd[128];
++
++
++	if (!data) {
++		wpa_printf(MSG_ERROR, "GREYLIST: %s: invalid data\n",
++				__func__);
++		return;
++	}
++
++	wpa_printf(MSG_DEBUG, "GREYLIST: Timeout expires for client :%s\n",
++			data->txtaddr);
++
++	/* Delete the entry from /nvram/greylist_mac.txt file */
++	interfaces = data->interfaces;
++	greylist_delete_from_file(interfaces, data->txtaddr);
++
++	for (i = 0; i < interfaces->count; i++) {
++		interface = interfaces->iface[i];
++		for (j = 0; j < interface->num_bss; j++) {
++			conf = interface->bss[j]->conf;
++			if (conf->rdk_greylist) {
++				wpa_printf(MSG_DEBUG,
++						"GREYLIST: %s: remove %s on %s\n",
++						__func__,
++						data->txtaddr,
++						conf->iface);
++				snprintf(cmd, sizeof(cmd), "wl -i %s mac del %s",
++						conf->iface, data->txtaddr);
++				system(cmd);
++			}
++		}
++	}
++
++	os_free(data);
++}
++
++
++/**
++ * greylist_add_to_driver - Add  mac to access control list of
++ * all greylist enabled vaps.
++ *
++ * The parameter 'txtaddr' can be a list of mac strings speparated by space.
++ */
++static void greylist_add_to_driver(struct hapd_interfaces *interfaces, const char *txtaddr)
++{
++	struct hostapd_iface *interface;
++	struct hostapd_bss_config *conf;
++	size_t i, j;
++	char cmd[128];
++
++	wpa_printf(MSG_DEBUG, "GREYLIST: %s: %s\n",
++			__func__, txtaddr);
++
++	for (i = 0; i < interfaces->count; i++) {
++		interface = interfaces->iface[i];
++		for (j = 0; j < interface->num_bss; j++) {
++			conf = interface->bss[j]->conf;
++			if (conf->rdk_greylist) {
++				wpa_printf(MSG_DEBUG,
++						"GREYLIST: %s: add %s to %s\n",
++						__func__,
++						txtaddr,
++						conf->iface);
++				snprintf(cmd, sizeof(cmd), "wl -i %s mac %s",
++						conf->iface, txtaddr);
++				system(cmd);
++			}
++		}
++	}
++}
++
++
++/**
++ * greylist_load - Read /nvram/greylist_mac.txt and handle each mac entry
++ *
++ * This function is used to parse /nvram/greylist_mac.txt at init time,
++ * add each mac to driver's acl, and register the timeout.
++ *
++ * The timeout handler removes the mac from driver's acl and greylist_mac.txt.
++ * The timeout value is 24 hour from the client's association time.
++ */
++void greylist_load(struct hapd_interfaces *interfaces)
++{
++	FILE *fp;
++	int fd, size = 0, max_size = 0;
++	char record_date[11] = {0}, record_time[9] = {0}, record_mac[TXT_MAC_ADDR_LEN] = {0};
++	char *macstr_list;
++	char time_buf[20] = {0};
++	time_t now, t;
++	struct tm time_info;
++	struct greylist_data *data;
++	unsigned int timeout;
++	struct hostapd_iface *interface;
++	struct hostapd_bss_config *conf;
++        int vap_index = -1;
++
++	wpa_printf(MSG_DEBUG, "GREYLIST: %s\n", __func__);
++
++	if (greylist_get_cmmac() == 0) {
++		wpa_printf(MSG_DEBUG, "GREYLIST: %s: cmmac=%s\n",
++				__func__, cmmac);
++	}
++
++	interface = interfaces->iface[0];
++	conf = interface->bss[0]->conf;
++
++	if ((fp = fopen(greylist_file, "r")) == NULL) {
++		wpa_printf(MSG_ERROR, "GREYLIST: %s: %s does not exist\n",
++				__func__, greylist_file);
++		return;
++	}
++	fd = fileno(fp);
++	if (fd == -1) {
++		wpa_printf(MSG_ERROR, "GREYLIST: %s: "
++				"fail to get fd\n", __func__);
++		fclose(fp);
++		return;
++	}
++
++	/* each mac is speparated by space */
++	max_size = GREYLIST_MAX_NUM_OF_RECORDS * TXT_MAC_ADDR_LEN;
++	macstr_list = os_zalloc(max_size);
++	if (macstr_list == NULL) {
++		wpa_printf(MSG_ERROR, "GREYLIST: %s: allocate memory for macstrlist"
++				"failed\n", __func__);
++		fclose(fp);
++		return;
++	}
++
++	wpa_printf(MSG_DEBUG,
++			"GREYLIST: %s: %s: trying to get file lock\n",
++			__func__, conf->iface);
++	flock(fd, LOCK_SH);
++	wpa_printf(MSG_DEBUG,
++			"GREYLIST: %s: %s: got file lock\n",
++			__func__, conf->iface);
++
++        while ((fscanf(fp, "%s %s %s %d", record_date, record_time, record_mac, &vap_index)) == 4) {
++		wpa_printf(MSG_DEBUG, "GREYLIST: %s: %s %s %s\n",
++				__func__, record_date, record_time, record_mac);
++
++		data = os_zalloc(sizeof(*data));
++		if (data == NULL) {
++			wpa_printf(MSG_ERROR, "GREYLIST: %s: %s: allocate memory"
++				"for eloop data failed\n", __func__, record_mac);
++			continue;
++		}
++
++		os_memset(&time_info, 0, sizeof(time_info));
++		snprintf(time_buf, sizeof(time_buf), "%s %s", record_date, record_time);
++		strptime(time_buf, "%Y-%m-%d %H:%M:%S", &time_info);
++		t = mktime(&time_info);
++		if (t == (time_t)-1) {
++			wpa_printf(MSG_ERROR, "GREYLIST: %s: %s %s %s:"
++					"time convert failed\n",
++					__func__, record_date, record_time, record_mac);
++			os_free(data);
++			continue;
++		}
++
++		time(&now);
++		if ((t > now)
++			|| (now - t > GREYLIST_TIMEOUT_IN_SECONDS)) {
++			timeout = 0;
++		}
++		else {
++			timeout = GREYLIST_TIMEOUT_IN_SECONDS - (now - t);
++		}
++
++		os_memcpy(data->txtaddr, record_mac, sizeof(data->txtaddr));
++		data->interfaces = interfaces;
++		wpa_printf(MSG_DEBUG, "GREYLIST: %s: %s: timeout=%u\n",
++				__func__, record_mac, timeout);
++		eloop_register_timeout(timeout, 0, greylist_timeout, data, NULL);
++
++		if (size == 0)
++			size = snprintf(macstr_list, max_size, "%s", record_mac);
++		else
++			size += snprintf(macstr_list + size, max_size - size, " %s", record_mac);
++	}
++	flock(fd, LOCK_UN);
++	wpa_printf(MSG_DEBUG,
++			"GREYLIST: %s: %s: released file lock\n",
++			__func__, conf->iface);
++
++	if (size > 0)
++		greylist_add_to_driver(interfaces, macstr_list);
++	free(macstr_list);
++	fclose(fp);
++}
++
++
++/**
++ * greylist_add - Add client's mac to greylist
++ *
++ * This function is used to add a client's mac to /nvram/greylist_mac.txt
++ * and acl of all greylist enabled vaps, and register a 24 hour timeout.
++ * The timeout handler removes the mac from greylist.
++ */
++
++int greylist_add(struct hostapd_data *hapd, const char *txtaddr, bool fromRadiusServer)
++{
++	FILE *fp;
++	int fd, num_of_records = 0;
++	char record_date[11] = {0}, record_time[9] = {0}, record_mac[TXT_MAC_ADDR_LEN] = {0};
++	char time_str[20] = {0};
++	struct greylist_data *data;
++	time_t now;
++	struct tm *time_info;
++	u32 timeout = GREYLIST_TIMEOUT_IN_SECONDS;
++	struct hostapd_bss_config *conf;
++        struct hapd_interfaces *interfaces;
++        int vap_index = -1;
++
++	wpa_printf(MSG_DEBUG, "GREYLIST: %s: %s\n", __func__, txtaddr);
++
++        conf = hapd->conf;
++        interfaces = hapd->iface->interfaces;
++
++	if ((fp = fopen(greylist_file, "a+")) == NULL) {
++		wpa_printf(MSG_DEBUG, "GREYLIST: %s: "
++				"fail to open %s\n", __func__, greylist_file);
++		return -1;
++	}
++	fd = fileno(fp);
++	if (fd == -1) {
++		wpa_printf(MSG_DEBUG, "GREYLIST: %s: "
++				"fail to get fd\n", __func__);
++		return -1;
++	}
++
++	/* When the client is rejected by the other hostapd instance
++	 * running on the other radio, this hostapd instance will
++	 * receive a message to add the client to greylist sent from
++	 * the other hostapd instance.
++	 *
++	 * Also, in any unexpected case if we receive multiple reject messages
++	 * from the server for the same client, no need to
++	 * add the mac again to the file */
++	wpa_printf(MSG_DEBUG, "GREYLIST: %s: %s: trying to get file lock\n",
++			__func__, conf->iface);
++	flock(fd, LOCK_SH);
++	wpa_printf(MSG_DEBUG, "GREYLIST: %s: %s: got file lock\n",
++			__func__, conf->iface);
++        while ((fscanf(fp, "%s %s %s %d", record_date, record_time, record_mac, &vap_index) == 4)) {
++		num_of_records++;
++		if (strcmp(record_mac, txtaddr) == 0) {
++			wpa_printf(MSG_ERROR, "GREYLIST: %s: "
++					"%s already exists in file\n",
++					__func__, txtaddr);
++			flock(fd, LOCK_UN);
++			wpa_printf(MSG_DEBUG,
++					"GREYLIST: %s: %s: released file lock\n",
++					__func__, conf->iface);
++			fclose(fp);
++			goto ADD_TO_DRIVER;
++		}
++	}
++	flock(fd, LOCK_UN);
++	wpa_printf(MSG_DEBUG,
++			"GREYLIST: %s: %s: released file lock\n",
++			__func__, conf->iface);
++
++	if (num_of_records >= GREYLIST_MAX_NUM_OF_RECORDS) {
++		wpa_printf(MSG_ERROR, "GREYLIST: %s: greylist is full\n", __func__);
++		fclose(fp);
++		return -1;
++	}
++
++        /* Get vap index */
++        vap_index = greylist_get_vap_index(conf->iface);
++
++	/* Get the current time and add the client mac and current time to the file */
++	time(&now);
++	time_info = localtime(&now);
++	strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S", time_info);
++	wpa_printf(MSG_DEBUG, "GREYLIST: %s: %s: trying to get file lock\n",
++			__func__, conf->iface);
++	flock(fd, LOCK_EX);
++	wpa_printf(MSG_DEBUG, "GREYLIST: %s: %s: got file lock\n",
++			__func__, conf->iface);
++	fseek(fp, 0, SEEK_END); //In case file position is updated by other processes
++        fprintf(fp, "%s %s %d\n", time_str, txtaddr, vap_index);
++	flock(fd, LOCK_UN);
++	wpa_printf(MSG_DEBUG,
++			"GREYLIST: %s: %s: released file lock\n",
++			__func__, conf->iface);
++	fclose(fp);
++
++ADD_TO_DRIVER:
++	/* TODO: check if already added to driver ? */
++	greylist_add_to_driver(interfaces, txtaddr);
++
++	data = os_zalloc(sizeof(*data));
++	if (data == NULL) {
++		wpa_printf(MSG_ERROR, "GREYLIST: %s: allocate memory failed\n",
++				__func__);
++		fclose(fp);
++		return -1;
++	}
++	os_memcpy(data->txtaddr, txtaddr, sizeof(data->txtaddr));
++	data->interfaces = interfaces;
++
++	wpa_printf(MSG_DEBUG, "GREYLIST: %s: register %u seconds timeout for %s\n",
++			__func__, timeout, txtaddr);
++	eloop_register_timeout(timeout, 0,
++				greylist_timeout, data, NULL);
++
++	greylist_log_to_file("%s Client added to grey list from RADIUS: %s\n",
++				time_str, txtaddr);
++
++//	/* Add to other hostapd instance running on the other radio */
++//	if (fromRadiusServer)
++//		greylist_add_to_other_hostapd(txtaddr);
++
++	return 0;
++}
++
++
++/**
++ * greylist_add_to_other_hostapd - Add the client to other hostapd's greylist
++ *
++ * This function is used to add the client mac to greylist of other hostapd
++ * instance(s) running for other radio(s), so other hostapd instance(s) will
++ * add the client's mac to all greylist enabled vaps controlled by it,
++ * and create a 24 hour timeout to delete the mac entry from driver
++ */
++int greylist_add_to_other_hostapd(const char *txtaddr)
++{
++	FILE *fp;
++	char cmd[256], pids_str[256];
++	char *token, *config_file_fullname = NULL, *config_filename = NULL;
++	char *pstart, *pend, *pch;
++	pid_t pid, current_pid;
++
++	current_pid = getpid();
++
++	wpa_printf(MSG_DEBUG, "GREYLIST: %s: current pid=%d\n",
++			__func__, current_pid);
++
++	/* Get pid of all hostapd instances */
++	snprintf(cmd, sizeof(cmd), "pidof hostapd");
++	wpa_printf(MSG_DEBUG, "GREYLIST: %s: %s\n",
++			__func__, cmd);
++	fp = popen(cmd, "r");
++	if (fp == NULL) {
++		wpa_printf(MSG_ERROR, "GREYLIST: %s: pidof failed\n",
++				__func__);
++		return -1;
++	}
++	fgets(pids_str, sizeof(pids_str), fp);
++	pclose(fp);
++
++	token = strtok(pids_str, " \n");
++	while (token != NULL) {
++		pid = atoi(token);
++		if (pid != current_pid) {
++			wpa_printf(MSG_DEBUG, "GREYLIST: %s: pid=%s\n",
++					__func__, token);
++
++			/* get primary interface name from config filename,
++			 * config file fullname is like /tmp/wl0_hapd.conf,
++			 * wl0 is the primary interface name */
++			snprintf(cmd, sizeof(cmd), "/proc/%s/cmdline", token);
++			fp = fopen(cmd, "r");
++			if (fp == NULL) {
++				wpa_printf(MSG_ERROR, "GREYLIST: %s: %s failed\n",
++						__func__, cmd);
++				return -1;
++			}
++			if (fgets(cmd, sizeof(cmd), fp)) {
++				pstart = cmd;
++				pend = cmd + sizeof(cmd);
++				while (pstart < pend) {
++					if (strstr(pstart, ".conf")) {
++						config_file_fullname = pstart;
++						break;
++					}
++					else
++						pstart += strlen(pstart) + 1;
++				}
++			}
++			fclose(fp);
++
++			if (!config_file_fullname) {
++				wpa_printf(MSG_ERROR, "GREYLIST: %s: config file not specified: %s\n",
++						__func__);
++				return -1;
++			}
++
++			wpa_printf(MSG_DEBUG, "GREYLIST: %s: config_file=%s\n",
++					__func__, config_file_fullname);
++			config_filename = strrchr(config_file_fullname, '/');
++			if (!config_filename)
++				config_filename = config_file_fullname;
++			else
++				++config_filename; //skip '/'
++			pch = strchr(config_filename, '_');
++			if (!pch) {
++				wpa_printf(MSG_ERROR, "GREYLIST: %s: unexpected config file: %s\n",
++						__func__, config_file_fullname);
++				return -1;
++			}
++			*pch = '\0'; //now config_filename only has ifname
++
++			snprintf(cmd, sizeof(cmd),
++				"hostapd_cli -i %s ADD_TO_GREYLIST %s",
++				config_filename, txtaddr);
++			wpa_printf(MSG_DEBUG, "GREYLIST: %s: %s\n",
++					__func__, cmd);
++			system(cmd);
++		}
++		token = strtok(NULL, " \n");
++	}
++
++	return 0;
++}
++
++
++/**
++ * greylist_get_client_snr - Get SNR of a client
++ */
++u8 greylist_get_client_snr(struct hostapd_data *hapd, const char *txtaddr)
++{
++	FILE *fp;
++	char cmd[128], buf[16];
++	int rssi = 0, nf;
++	u8 snr = 0;
++
++	/* Get rssi with command 'wl rssi' */
++	snprintf(cmd, sizeof(cmd), "wl -i %s rssi %s", hapd->conf->iface, txtaddr);
++	wpa_printf(MSG_DEBUG, "GREYLIST: %s: %s\n",
++			__func__, cmd);
++	fp = popen(cmd, "r");
++
++	if (fp == NULL) {
++		wpa_printf(MSG_ERROR, "GREYLIST: %s: get rssi failed\n",
++				__func__);
++		return 0;
++	}
++
++	fgets(buf, sizeof(buf), fp);
++	pclose(fp);
++	rssi = atoi(buf);
++
++	/* Get noise floor with command 'wl chanim_stats' */
++	snprintf(cmd, sizeof(cmd),
++			"wl -i %s chanim_stats | awk \'NR == 3 {print $13}\'",
++			hapd->conf->iface);
++	wpa_printf(MSG_DEBUG, "GREYLIST: %s: %s\n",
++			__func__, cmd);
++	fp = popen(cmd, "r");
++
++	if (fp == NULL) {
++		wpa_printf(MSG_ERROR, "GREYLIST: %s: get noise floor failed\n",
++				__func__);
++		return 0;
++	}
++
++	fgets(buf, sizeof(buf), fp);
++	pclose(fp);
++	nf = atoi(buf);
++	snr = (u8)(rssi - nf);
++	wpa_printf(MSG_DEBUG, "GREYLIST: %s: txtaddr=%s rssi=%d nf=%d snr=%u\n",
++			__func__, txtaddr, rssi, nf, snr);
++	return snr;
++}
+diff --git a/src/ap/greylist.h b/src/ap/greylist.h
+new file mode 100644
+index 000000000..18ac49093
+--- /dev/null
++++ b/src/ap/greylist.h
+@@ -0,0 +1,25 @@
++/*
++ * hostapd / RADIUS Greylist Access Control
++ *
++ * RadiusGreylist is the feature controlled by RFC
++ * this feature will add the clients mac to public vaps maclist,
++ * which  are connected to public vaps from their own device
++ * Implementations and declaration are present here.
++ *
++ *
++ *
++ */
++
++#ifndef GREYLIST_H
++#define GREYLIST_H
++
++#include "hostapd.h"
++
++#define TXT_MAC_ADDR_LEN 18 /* Including ending '\0' */
++
++extern char cmmac[];
++void greylist_load(struct hapd_interfaces *interfaces);
++int greylist_add(struct hostapd_data *hapd, const char *txtaddr, bool fromRadiusServer);
++u8 greylist_get_client_snr(struct hostapd_data *hapd, const char *txtaddr);
++
++#endif /* GREYLIST_H */
+\ No newline at end of file
+diff --git a/src/ap/hostapd.c b/src/ap/hostapd.c
+index ef53c41df..ff39e9ddc 100644
+--- a/src/ap/hostapd.c
++++ b/src/ap/hostapd.c
+@@ -57,10 +57,10 @@
+ #include "wpa_auth_kay.h"
+ 
+ 
+-static int hostapd_flush_old_stations(struct hostapd_data *hapd, u16 reason);
++int hostapd_flush_old_stations(struct hostapd_data *hapd, u16 reason);
+ #ifdef CONFIG_WEP
+-static int hostapd_setup_encryption(char *iface, struct hostapd_data *hapd);
+-static int hostapd_broadcast_wep_clear(struct hostapd_data *hapd);
++int hostapd_setup_encryption(char *iface, struct hostapd_data *hapd);
++int hostapd_broadcast_wep_clear(struct hostapd_data *hapd);
+ #endif /* CONFIG_WEP */
+ static int setup_interface2(struct hostapd_iface *iface);
+ static void channel_list_update_timeout(void *eloop_ctx, void *timeout_ctx);
+@@ -301,7 +301,7 @@ int hostapd_reload_config(struct hostapd_iface *iface)
+ 
+ #ifdef CONFIG_WEP
+ 
+-static void hostapd_broadcast_key_clear_iface(struct hostapd_data *hapd,
++void hostapd_broadcast_key_clear_iface(struct hostapd_data *hapd,
+ 					      const char *ifname)
+ {
+ 	int i;
+@@ -330,14 +330,14 @@ static void hostapd_broadcast_key_clear_iface(struct hostapd_data *hapd,
+ }
+ 
+ 
+-static int hostapd_broadcast_wep_clear(struct hostapd_data *hapd)
++int hostapd_broadcast_wep_clear(struct hostapd_data *hapd)
+ {
+ 	hostapd_broadcast_key_clear_iface(hapd, hapd->conf->iface);
+ 	return 0;
+ }
+ 
+ 
+-static int hostapd_broadcast_wep_set(struct hostapd_data *hapd)
++int hostapd_broadcast_wep_set(struct hostapd_data *hapd)
+ {
+ 	int errors = 0, idx;
+ 	struct hostapd_ssid *ssid = &hapd->conf->ssid;
+@@ -494,7 +494,7 @@ static void hostapd_cleanup(struct hostapd_data *hapd)
+ }
+ 
+ 
+-static void sta_track_deinit(struct hostapd_iface *iface)
++void sta_track_deinit(struct hostapd_iface *iface)
+ {
+ 	struct hostapd_sta_info *info;
+ 
+@@ -567,7 +567,7 @@ static void hostapd_clear_wep(struct hostapd_data *hapd)
+ }
+ 
+ 
+-static int hostapd_setup_encryption(char *iface, struct hostapd_data *hapd)
++int hostapd_setup_encryption(char *iface, struct hostapd_data *hapd)
+ {
+ 	int i;
+ 
+@@ -608,7 +608,7 @@ static int hostapd_setup_encryption(char *iface, struct hostapd_data *hapd)
+ #endif /* CONFIG_WEP */
+ 
+ 
+-static int hostapd_flush_old_stations(struct hostapd_data *hapd, u16 reason)
++int hostapd_flush_old_stations(struct hostapd_data *hapd, u16 reason)
+ {
+ 	int ret = 0;
+ 	u8 addr[ETH_ALEN];
+@@ -1115,7 +1115,7 @@ static int db_table_create_radius_attributes(sqlite3 *db)
+  * initialized. Most of the modules that are initialized here will be
+  * deinitialized in hostapd_cleanup().
+  */
+-static int hostapd_setup_bss(struct hostapd_data *hapd, int first)
++int hostapd_setup_bss(struct hostapd_data *hapd, int first)
+ {
+ 	struct hostapd_bss_config *conf = hapd->conf;
+ 	u8 ssid[SSID_MAX_LEN + 1];
+@@ -1287,7 +1287,11 @@ static int hostapd_setup_bss(struct hostapd_data *hapd, int first)
+ 		return -1;
+ 	}
+ 
+-	if (conf->radius_das_port) {
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++        if (conf->radius_das_port && conf->rdk_greylist) {
++#else /* FEATURE_SUPPORT_RADIUSGREYLIST */
++        if (conf->radius_das_port) {
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 		struct radius_das_conf das_conf;
+ 		os_memset(&das_conf, 0, sizeof(das_conf));
+ 		das_conf.port = conf->radius_das_port;
+@@ -1411,6 +1415,17 @@ static int hostapd_setup_bss(struct hostapd_data *hapd, int first)
+ 	if (hapd->driver && hapd->driver->set_operstate)
+ 		hapd->driver->set_operstate(hapd->drv_priv, 1);
+ 
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++	if ((conf->rdk_greylist || conf->connected_building_avp) && !conf->ieee802_1x) {
++		char cmd[128];
++
++		snprintf(cmd, sizeof(cmd), "wl -i %s eap_restrict 1",
++			conf->iface);
++		wpa_printf(MSG_DEBUG, "GREYLIST: %s: %s", __func__, cmd);
++		system(cmd);
++	}
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
++
+ 	return 0;
+ }
+ 
+@@ -1627,9 +1642,6 @@ static int setup_interface(struct hostapd_iface *iface)
+ 		if (os_strncmp(previous_country, country, 2) != 0) {
+ 			wpa_printf(MSG_DEBUG, "Continue interface setup after channel list update");
+ 			iface->wait_channel_update = 1;
+-			eloop_register_timeout(5, 0,
+-					       channel_list_update_timeout,
+-					       iface, NULL);
+ 			return 0;
+ 		}
+ 	}
+@@ -3239,6 +3251,10 @@ void hostapd_new_assoc_sta(struct hostapd_data *hapd, struct sta_info *sta,
+ 	 * been authorized. */
+ 	if (!hapd->conf->ieee802_1x && !hapd->conf->wpa && !hapd->conf->osen) {
+ 		ap_sta_set_authorized(hapd, sta, 1);
++#ifdef _PLATFORM_RASPBERRYPI_
++		/*When Station is connected with OPEN Mode, need to authorize the station */
++		hostapd_set_authorized(hapd, sta, 1);
++#endif
+ 		os_get_reltime(&sta->connected_time);
+ 		accounting_sta_start(hapd, sta);
+ 	}
+@@ -3866,7 +3882,10 @@ struct hostapd_data * hostapd_get_iface(struct hapd_interfaces *interfaces,
+ 					const char *ifname)
+ {
+ 	size_t i, j;
+-
++    if(interfaces->iface == NULL) {
++        wpa_printf(MSG_ERROR, "%s:%d iface is NULL", __func__, __LINE__);
++        return NULL;
++    }
+ 	for (i = 0; i < interfaces->count; i++) {
+ 		struct hostapd_iface *iface = interfaces->iface[i];
+ 
+@@ -3921,3 +3940,36 @@ void hostapd_ocv_check_csa_sa_query(void *eloop_ctx, void *timeout_ctx)
+ 	}
+ }
+ #endif /* CONFIG_OCV */
++
++#ifdef CONFIG_DRIVER_BRCM
++/*
++ * start beaconing on virtual BSS iface on ifconfig up
++ */
++void hostapd_set_beacon_on_vif(struct hostapd_data *hapd)
++{
++	struct hostapd_bss_config *conf = hapd->conf;
++	hapd->disabled = 0;
++
++	if ((conf->start_disabled == 1)  && (hapd->bss_started == 0)) {
++		wpa_printf(MSG_DEBUG, "%s: hapd %p, start_disabled %d, bss_started %d. return",
++				conf->iface, hapd, conf->start_disabled, hapd->bss_started);
++		return;
++	}
++
++	hapd->reenable_beacon = 1;
++	if (ieee802_11_set_beacon(hapd) < 0) {
++		wpa_printf(MSG_ERROR, "%s: setting beacon failed", conf->iface);
++	} else {
++		wpa_printf(MSG_DEBUG, "%s: setting beacon success", conf->iface);
++	}
++}
++
++/*
++ * stop beaconing on vritual BSS iface on ifconfig down
++ */
++void hostapd_stop_beacon_on_vif(struct hostapd_data *hapd)
++{
++	wpa_printf(MSG_INFO, "%s: stop beacon", hapd->conf->iface);
++	hapd->disabled = 1;
++}
++#endif /* CONFIG_DRIVER_BRCM */
+diff --git a/src/ap/hostapd.h b/src/ap/hostapd.h
+index 297faaf14..d90cc508e 100644
+--- a/src/ap/hostapd.h
++++ b/src/ap/hostapd.h
+@@ -161,7 +161,9 @@ struct hostapd_data {
+ 	unsigned int started:1;
+ 	unsigned int disabled:1;
+ 	unsigned int reenable_beacon:1;
+-
++#ifdef CONFIG_DRIVER_BRCM
++	unsigned int bss_started:1; /* BSS started/stopped from cli - start_bss/stop_bss */
++#endif /* CONFIG_DRIVER_BRCM */
+ 	u8 own_addr[ETH_ALEN];
+ 
+ 	int num_sta; /* number of entries in sta_list */
+@@ -233,7 +235,13 @@ struct hostapd_data {
+ 	struct eth_p_oui_ctx *oui_sreq;
+ 	struct eth_p_oui_ctx *oui_sresp;
+ #endif /* CONFIG_IEEE80211R_AP */
+-
++#ifdef CONFIG_DRIVER_BRCM
++	struct eth_p_oui_ctx *lo_oui_pull;
++	struct eth_p_oui_ctx *lo_oui_resp;
++	struct eth_p_oui_ctx *lo_oui_push;
++	struct eth_p_oui_ctx *lo_oui_sreq;
++	struct eth_p_oui_ctx *lo_oui_sresp;
++#endif /* CONFIG_DRIVER_BRCM */
+ 	struct wps_context *wps;
+ 
+ 	int beacon_set_done;
+@@ -531,6 +539,7 @@ struct hostapd_iface {
+ 	 * current_mode->channels */
+ 	int num_rates;
+ 	struct hostapd_rate_data *current_rates;
++	struct hostapd_rate_data *current_cac_rates;
+ 	int *basic_rates;
+ 	int freq;
+ 
+@@ -718,12 +727,21 @@ struct hostapd_data * hostapd_get_iface(struct hapd_interfaces *interfaces,
+ void hostapd_event_sta_opmode_changed(struct hostapd_data *hapd, const u8 *addr,
+ 				      enum smps_mode smps_mode,
+ 				      enum chan_width chan_width, u8 rx_nss);
++int hostapd_setup_bss(struct hostapd_data *hapd, int first);
++void hostapd_free_hapd_data(struct hostapd_data *hapd);
++void hostapd_bss_deinit_no_free(struct hostapd_data *hapd);
+ 
+ #ifdef CONFIG_FST
+ void fst_hostapd_fill_iface_obj(struct hostapd_data *hapd,
+ 				struct fst_wpa_obj *iface_obj);
+ #endif /* CONFIG_FST */
+ 
++/*struct hapd_global {
++        void **drv_priv;
++        size_t drv_count;
++};*/
++
++extern struct hapd_global global;
+ int hostapd_set_acl(struct hostapd_data *hapd);
+ 
+ #endif /* HOSTAPD_H */
+diff --git a/src/ap/ieee802_11.c b/src/ap/ieee802_11.c
+index 394e292bd..31fab3e03 100644
+--- a/src/ap/ieee802_11.c
++++ b/src/ap/ieee802_11.c
+@@ -55,7 +55,9 @@
+ #include "fils_hlp.h"
+ #include "dpp_hostapd.h"
+ #include "gas_query_ap.h"
+-
++#if defined(CONFIG_DRIVER_BRCM) && defined(CONFIG_DRIVER_BRCM_CEVENT)
++#include "ce_shared.h"
++#endif /* CONFIG_DRIVER_BRCM && CONFIG_DRIVER_BRCM_CEVENT */
+ 
+ #ifdef CONFIG_FILS
+ static struct wpabuf *
+@@ -109,7 +111,7 @@ u8 * hostapd_eid_supp_rates(struct hostapd_data *hapd, u8 *eid)
+ 	int i, num, count;
+ 	int h2e_required;
+ 
+-	if (hapd->iface->current_rates == NULL)
++        if ((hapd->iface->current_rates == NULL) && (hapd->iface->current_cac_rates == NULL))
+ 		return eid;
+ 
+ 	*pos++ = WLAN_EID_SUPP_RATES;
+@@ -131,14 +133,25 @@ u8 * hostapd_eid_supp_rates(struct hostapd_data *hapd, u8 *eid)
+ 	}
+ 
+ 	*pos++ = num;
+-	for (i = 0, count = 0; i < hapd->iface->num_rates && count < num;
+-	     i++) {
+-		count++;
+-		*pos = hapd->iface->current_rates[i].rate / 5;
+-		if (hapd->iface->current_rates[i].flags & HOSTAPD_RATE_BASIC)
+-			*pos |= 0x80;
+-		pos++;
+-	}
++        if(hapd->iface->current_cac_rates) {
++                for (i = 0, count = 0; i < hapd->iface->num_rates && count < num;
++                                i++) {
++                        count++;
++                        *pos = hapd->iface->current_cac_rates[i].rate / 5;
++                        if (hapd->iface->current_cac_rates[i].flags & HOSTAPD_RATE_BASIC)
++                                *pos |= 0x80;
++                        pos++;
++                }
++        } else {
++                for (i = 0, count = 0; i < hapd->iface->num_rates && count < num;
++                                i++) {
++                        count++;
++                        *pos = hapd->iface->current_rates[i].rate / 5;
++                        if (hapd->iface->current_rates[i].flags & HOSTAPD_RATE_BASIC)
++                                *pos |= 0x80;
++                        pos++;
++                }
++        }
+ 
+ 	if (hapd->iconf->ieee80211n && hapd->iconf->require_ht && count < 8) {
+ 		count++;
+@@ -290,7 +303,7 @@ u16 hostapd_own_capab_info(struct hostapd_data *hapd)
+ 	 * TODO: Also consider driver support for TPC to set Spectrum Mgmt bit
+ 	 */
+ 	if (hapd->iface->current_mode &&
+-	    hapd->iface->current_mode->mode == HOSTAPD_MODE_IEEE80211A &&
++	    /*hapd->iface->current_mode->mode == HOSTAPD_MODE_IEEE80211A &&*/
+ 	    (hapd->iconf->spectrum_mgmt_required || dfs))
+ 		capab |= WLAN_CAPABILITY_SPECTRUM_MGMT;
+ 
+@@ -669,7 +682,12 @@ static int auth_sae_send_commit(struct hostapd_data *hapd,
+ 				    WLAN_AUTH_SAE, 1,
+ 				    status, wpabuf_head(data),
+ 				    wpabuf_len(data), "sae-send-commit");
+-
++#if defined(CONFIG_DRIVER_BRCM) && defined(CONFIG_DRIVER_BRCM_CEVENT)
++	if (!reply_res) {
++		CE_SEND_CEVENT_A2C_EXT(hapd->conf->iface, (struct ether_addr *)sta->addr, 0, 0,
++			CEVENT_ST_HOSTAPD, CEVENT_A2C_MT_AUTH_COMMIT_TX, CEVENT_FRAME_DIR_TX, NULL, 0);
++	}
++#endif /* CONFIG_DRIVER_BRCM && CONFIG_DRIVER_BRCM_CEVENT */
+ 	wpabuf_free(data);
+ 
+ 	return reply_res;
+@@ -691,7 +709,12 @@ static int auth_sae_send_confirm(struct hostapd_data *hapd,
+ 				    WLAN_AUTH_SAE, 2,
+ 				    WLAN_STATUS_SUCCESS, wpabuf_head(data),
+ 				    wpabuf_len(data), "sae-send-confirm");
+-
++#if defined(CONFIG_DRIVER_BRCM) && defined(CONFIG_DRIVER_BRCM_CEVENT)
++	if (!reply_res) {
++		CE_SEND_CEVENT_A2C_EXT(hapd->conf->iface, (struct ether_addr *)sta->addr, 0, 0,
++			CEVENT_ST_HOSTAPD, CEVENT_A2C_MT_AUTH_CONFIRM_TX, CEVENT_FRAME_DIR_TX, NULL, 0);
++	}
++#endif /* CONFIG_DRIVER_BRCM && CONFIG_DRIVER_BRCM_CEVENT */
+ 	wpabuf_free(data);
+ 
+ 	return reply_res;
+@@ -1362,6 +1385,10 @@ static void handle_auth_sae(struct hostapd_data *hapd, struct sta_info *sta,
+ 		size_t token_len = 0;
+ 		int allow_reuse = 0;
+ 
++#if defined(CONFIG_DRIVER_BRCM) && defined(CONFIG_DRIVER_BRCM_CEVENT)
++		CE_SEND_CEVENT_A2C_EXT(hapd->conf->iface, (struct ether_addr *)sta->addr, 0, 0,
++			CEVENT_ST_HOSTAPD, CEVENT_A2C_MT_AUTH_COMMIT_RX, CEVENT_FRAME_DIR_RX, NULL, 0);
++#endif /* CONFIG_DRIVER_BRCM && CONFIG_DRIVER_BRCM_CEVENT */
+ 		hostapd_logger(hapd, sta->addr, HOSTAPD_MODULE_IEEE80211,
+ 			       HOSTAPD_LEVEL_DEBUG,
+ 			       "start SAE authentication (RX commit, status=%u (%s))",
+@@ -1522,6 +1549,10 @@ static void handle_auth_sae(struct hostapd_data *hapd, struct sta_info *sta,
+ 		resp = sae_sm_step(hapd, sta, mgmt->bssid, auth_transaction,
+ 				   status_code, allow_reuse, &sta_removed);
+ 	} else if (auth_transaction == 2) {
++#if defined(CONFIG_DRIVER_BRCM) && defined(CONFIG_DRIVER_BRCM_CEVENT)
++		CE_SEND_CEVENT_A2C_EXT(hapd->conf->iface, (struct ether_addr *)sta->addr, 0, 0,
++			CEVENT_ST_HOSTAPD, CEVENT_A2C_MT_AUTH_CONFIRM_RX, CEVENT_FRAME_DIR_RX, NULL, 0);
++#endif /* CONFIG_DRIVER_BRCM && CONFIG_DRIVER_BRCM_CEVENT */
+ 		hostapd_logger(hapd, sta->addr, HOSTAPD_MODULE_IEEE80211,
+ 			       HOSTAPD_LEVEL_DEBUG,
+ 			       "SAE authentication (RX confirm, status=%u (%s))",
+@@ -3866,7 +3897,11 @@ static void handle_auth(struct hostapd_data *hapd,
+ 			goto fail;
+ 		}
+ 	}
+-
++#ifdef CONFIG_DRIVER_BRCM
++        else {
++                sta->added_unassoc = 1;
++        }
++#endif /* CONFIG_DRIVER_BRCM */
+ 	switch (auth_alg) {
+ 	case WLAN_AUTH_OPEN:
+ 		hostapd_logger(hapd, sta->addr, HOSTAPD_MODULE_IEEE80211,
+@@ -5036,7 +5071,7 @@ static int add_associated_sta(struct hostapd_data *hapd,
+ }
+ 
+ 
+-static u16 send_assoc_resp(struct hostapd_data *hapd, struct sta_info *sta,
++u16 send_assoc_resp(struct hostapd_data *hapd, struct sta_info *sta,
+ 			   const u8 *addr, u16 status_code, int reassoc,
+ 			   const u8 *ies, size_t ies_len, int rssi,
+ 			   int omit_rsnxe)
+@@ -5559,6 +5594,9 @@ static void handle_assoc(struct hostapd_data *hapd,
+ 		 * entry in the driver as associated and not authenticated
+ 		 */
+ 		sta->flags |= WLAN_STA_AUTH;
++#ifdef CONFIG_DRIVER_BRCM
++		sta->added_unassoc = 1;
++#endif /* CONFIG_DRIVER_BRCM */
+ 	} else
+ #endif /* CONFIG_IEEE80211R_AP */
+ 	if (sta == NULL || (sta->flags & WLAN_STA_AUTH) == 0) {
+@@ -5609,6 +5647,29 @@ static void handle_assoc(struct hostapd_data *hapd,
+ 			wpa_auth_sm_event(sta->wpa_sm, WPA_AUTH);
+ 			sta->auth_alg = WLAN_AUTH_OPEN;
+ 		} else {
++#ifdef CONFIG_DRIVER_BRCM
++                        sta = ap_sta_add(hapd, mgmt->sa);
++                        if (!sta) {
++                                hostapd_logger(hapd, mgmt->sa,
++                                               HOSTAPD_MODULE_IEEE80211,
++                                               HOSTAPD_LEVEL_INFO,
++                                               "Failed to add STA");
++                                resp = WLAN_STATUS_AP_UNABLE_TO_HANDLE_NEW_STA;
++                                goto fail;
++                        }
++                        hostapd_logger(hapd, sta->addr,
++                                       HOSTAPD_MODULE_IEEE80211,
++                                       HOSTAPD_LEVEL_DEBUG,
++                                       "Skip authentication for DMG/IEEE 802.11ad");
++                        sta->flags |= WLAN_STA_AUTH;
++                        wpa_auth_sm_event(sta->wpa_sm, WPA_AUTH);
++                        sta->auth_alg = WLAN_AUTH_OPEN;
++                        /* It comes here only when STA is already authenticated by the driver
++                         * and association request is getting handled by hostapd.
++                         * So set added_unassoc flag here.
++                         */
++                        sta->added_unassoc = 1;
++#else
+ 			hostapd_logger(hapd, mgmt->sa,
+ 				       HOSTAPD_MODULE_IEEE80211,
+ 				       HOSTAPD_LEVEL_INFO,
+@@ -5618,9 +5679,15 @@ static void handle_assoc(struct hostapd_data *hapd,
+ 			send_deauth(hapd, mgmt->sa,
+ 				    WLAN_REASON_CLASS2_FRAME_FROM_NONAUTH_STA);
+ 			return;
++#endif /* CONFIG_DRIVER_BRCM */
+ 		}
+ 	}
+ 
++	os_free(sta->assoc_req);
++	sta->assoc_req = os_malloc(len);
++	os_memcpy(sta->assoc_req, (u8 *)mgmt, len);
++	sta->assoc_req_len = len;
++
+ 	if ((fc & WLAN_FC_RETRY) &&
+ 	    sta->last_seq_ctrl != WLAN_INVALID_MGMT_SEQ &&
+ 	    sta->last_seq_ctrl == seq_ctrl &&
+@@ -6038,7 +6105,7 @@ static int handle_action(struct hostapd_data *hapd,
+ 			   mgmt->u.action.category, MAC2STR(mgmt->sa));
+ 		return 0;
+ 	}
+-
++#ifndef CONFIG_DRIVER_BRCM
+ 	if (sta && (sta->flags & WLAN_STA_MFP) &&
+ 	    !(mgmt->frame_control & host_to_le16(WLAN_FC_ISWEP)) &&
+ 	    robust_action_frame(mgmt->u.action.category)) {
+@@ -6048,6 +6115,7 @@ static int handle_action(struct hostapd_data *hapd,
+ 			       "an MFP STA");
+ 		return 0;
+ 	}
++#endif /* !CONFIG_DRIVER_BRCM */
+ 
+ 	if (sta) {
+ 		u16 fc = le_to_host16(mgmt->frame_control);
+@@ -7027,6 +7095,35 @@ u8 * hostapd_eid_txpower_envelope(struct hostapd_data *hapd, u8 *eid)
+ 						   tx_pwr);
+ 		}
+ 
++		switch (hostapd_get_oper_chwidth(iconf)) {
++		case CHANWIDTH_USE_HT:
++			if (iconf->secondary_channel == 0) {
++				/* Max Transmit Power count = 0 (20 MHz) */
++				tx_pwr_count = 0;
++			} else {
++				/* Max Transmit Power count = 1 (20, 40 MHz) */
++				tx_pwr_count = 1;
++			}
++			break;
++		case CHANWIDTH_80MHZ:
++			/* Max Transmit Power count = 2 (20, 40, and 80 MHz) */
++			tx_pwr_count = 2;
++			break;
++		case CHANWIDTH_80P80MHZ:
++		case CHANWIDTH_160MHZ:
++			/* Max Transmit Power count = 3 (20, 40, 80, 160/80+80 MHz) */
++			tx_pwr_count = 3;
++			break;
++		default:
++			return eid;
++		}
++
++		if (iconf->reg_def_cli_eirp != -1)
++			eid = hostapd_add_tpe_info(
++				eid, tx_pwr_count, REGULATORY_CLIENT_EIRP,
++				REG_DEFAULT_CLIENT,
++				hapd->iconf->reg_def_cli_eirp);
++
+ 		return eid;
+ 	}
+ #endif /* CONFIG_IEEE80211AX */
+@@ -7319,6 +7416,9 @@ size_t hostapd_eid_rnr_len(struct hostapd_data *hapd, u32 type)
+ 		/* fallthrough */
+ 
+ 	case WLAN_FC_STYPE_PROBE_RESP:
++		total_len += hostapd_drv_eid_rnr_colocation_len(hapd,
++								&current_len);
++
+ 		if (mode == COLOCATED_LOWER_BAND)
+ 			total_len += hostapd_eid_rnr_colocation_len(
+ 				hapd, &current_len);
+@@ -7520,6 +7620,8 @@ u8 * hostapd_eid_rnr(struct hostapd_data *hapd, u8 *eid, u32 type)
+ 		/* fallthrough */
+ 
+ 	case WLAN_FC_STYPE_PROBE_RESP:
++		eid = hostapd_drv_eid_rnr_colocation(hapd, eid, &current_len);
++
+ 		if (mode == COLOCATED_LOWER_BAND)
+ 			eid = hostapd_eid_rnr_colocation(hapd, eid,
+ 							 &current_len);
+diff --git a/src/ap/ieee802_11.h b/src/ap/ieee802_11.h
+index fa1f47b95..3ee1d1967 100644
+--- a/src/ap/ieee802_11.h
++++ b/src/ap/ieee802_11.h
+@@ -215,4 +215,9 @@ u16 copy_sta_eht_capab(struct hostapd_data *hapd, struct sta_info *sta,
+ 		       const u8 *he_capab, size_t he_capab_len,
+ 		       const u8 *eht_capab, size_t eht_capab_len);
+ 
++u16 send_assoc_resp(struct hostapd_data *hapd, struct sta_info *sta,
++			   const u8 *addr, u16 status_code, int reassoc,
++			   const u8 *ies, size_t ies_len, int rssi,
++			   int omit_rsnxe);
++
+ #endif /* IEEE802_11_H */
+diff --git a/src/ap/ieee802_11_he.c b/src/ap/ieee802_11_he.c
+index 1e74c5845..e413737c0 100644
+--- a/src/ap/ieee802_11_he.c
++++ b/src/ap/ieee802_11_he.c
+@@ -118,6 +118,9 @@ u8 * hostapd_eid_he_capab(struct hostapd_data *hapd, u8 *eid,
+ 		break;
+ 	}
+ 
++	if (!hapd->iface->conf->he_2ghz_40mhz_width_allowed)
++		he_oper_chwidth &= ~HE_PHYCAP_CHANNEL_WIDTH_SET_40MHZ_IN_2G;
++
+ 	ie_size += mcs_nss_size + ppet_size;
+ 
+ 	*pos++ = WLAN_EID_EXTENSION;
+@@ -176,6 +179,9 @@ u8 * hostapd_eid_he_operation(struct hostapd_data *hapd, u8 *eid)
+ 	if (!hapd->iface->current_mode)
+ 		return eid;
+ 
++	if (hapd->iface->conf->he_op.he_cohosted_bss)
++		oper_size += 1;
++
+ 	if (is_6ghz_op_class(hapd->iconf->op_class))
+ 		oper_size += 5;
+ 
+@@ -216,6 +222,11 @@ u8 * hostapd_eid_he_operation(struct hostapd_data *hapd, u8 *eid)
+ 
+ 	pos += 6; /* skip the fixed part */
+ 
++	if (hapd->iface->conf->he_op.he_cohosted_bss) {
++		params |= HE_OPERATION_COHOSTED_BSS;
++		*pos++ = hapd->iface->conf->he_op.he_max_cohosted_bssid;
++	}
++
+ 	if (is_6ghz_op_class(hapd->iconf->op_class)) {
+ 		u8 seg0 = hostapd_get_oper_centr_freq_seg0_idx(hapd->iconf);
+ 		u8 seg1 = hostapd_get_oper_centr_freq_seg1_idx(hapd->iconf);
+diff --git a/src/ap/ieee802_11_ht.c b/src/ap/ieee802_11_ht.c
+index 59ecbdce7..07938d562 100644
+--- a/src/ap/ieee802_11_ht.c
++++ b/src/ap/ieee802_11_ht.c
+@@ -39,6 +39,15 @@ u8 * hostapd_eid_ht_capabilities(struct hostapd_data *hapd, u8 *eid)
+ 	cap->a_mpdu_params = hapd->iface->current_mode->a_mpdu_params;
+ 	os_memcpy(cap->supported_mcs_set, hapd->iface->current_mode->mcs_set,
+ 		  16);
++  u8 *supp_mcs_set = cap->supported_mcs_set;
++  wpa_printf(MSG_DEBUG, "Enter %s %d and min_adv_mcs:%d for the interface:%s\n", __func__,__LINE__,hapd->conf->min_adv_mcs,hapd->conf->iface);
++  while (*supp_mcs_set) {
++    for(int i=0;i<hapd->conf->min_adv_mcs;i++) {
++      *supp_mcs_set &= ~(1<<i);
++    }
++    wpa_printf(MSG_DEBUG, "Enter %s %d and supp_mcs_set:%d\n", __func__,__LINE__,*supp_mcs_set);
++    *supp_mcs_set++;
++  }
+ 
+ 	/* TODO: ht_extended_capabilities (now fully disabled) */
+ 	/* TODO: tx_bf_capability_info (now fully disabled) */
+@@ -96,6 +105,10 @@ u8 * hostapd_eid_ht_operation(struct hostapd_data *hapd, u8 *eid)
+ 
+ 	oper->primary_chan = hapd->iconf->channel;
+ 	oper->operation_mode = host_to_le16(hapd->iface->ht_op_mode);
++
++	if (hapd->iconf->ht_rifs == 1)
++		oper->ht_param |= HT_INFO_HT_PARAM_RIFS_MODE;
++
+ 	if (hapd->iconf->secondary_channel == 1)
+ 		oper->ht_param |= HT_INFO_HT_PARAM_SECONDARY_CHNL_ABOVE |
+ 			HT_INFO_HT_PARAM_STA_CHNL_WIDTH;
+@@ -103,6 +116,16 @@ u8 * hostapd_eid_ht_operation(struct hostapd_data *hapd, u8 *eid)
+ 		oper->ht_param |= HT_INFO_HT_PARAM_SECONDARY_CHNL_BELOW |
+ 			HT_INFO_HT_PARAM_STA_CHNL_WIDTH;
+ 
++	u8 *basic_mcs_set = oper->basic_mcs_set;
++	wpa_printf(MSG_DEBUG, "Enter %s %d and min_adv_mcs:%d for the interface:%s\n", __func__,__LINE__,hapd->conf->min_adv_mcs,hapd->conf->iface);
++	while (*basic_mcs_set) {
++		for(int i=0;i<hapd->conf->min_adv_mcs;i++) {
++		*basic_mcs_set &= ~(1<<i);
++		}
++		wpa_printf(MSG_DEBUG, "Enter %s %d and basic_mcs_set:%d\n", __func__,__LINE__,*basic_mcs_set);
++		*basic_mcs_set++;
++	}
++
+ 	pos += sizeof(*oper);
+ 
+ 	return pos;
+diff --git a/src/ap/ieee802_11_vht.c b/src/ap/ieee802_11_vht.c
+index 828f0abb5..f0c888834 100644
+--- a/src/ap/ieee802_11_vht.c
++++ b/src/ap/ieee802_11_vht.c
+@@ -119,7 +119,8 @@ u8 * hostapd_eid_vht_operation(struct hostapd_data *hapd, u8 *eid)
+ 
+ 	/* VHT Basic MCS set comes from hw */
+ 	/* Hard code 1 stream, MCS0-7 is a min Basic VHT MCS rates */
+-	oper->vht_basic_mcs_set = host_to_le16(0xfffc);
++	//oper->vht_basic_mcs_set = host_to_le16(0xfffc);
++	oper->vht_basic_mcs_set = host_to_le16(hapd->iconf->vht_oper_basic_mcs_set);
+ 	pos += sizeof(*oper);
+ 
+ 	return pos;
+diff --git a/src/ap/ieee802_1x.c b/src/ap/ieee802_1x.c
+index fb5e92060..b8d177c3d 100644
+--- a/src/ap/ieee802_1x.c
++++ b/src/ap/ieee802_1x.c
+@@ -38,7 +38,9 @@
+ #include "ieee802_11.h"
+ #include "ieee802_1x.h"
+ #include "wpa_auth_kay.h"
+-
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++#include "ap/greylist.h"
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 
+ #ifdef CONFIG_HS20
+ static void ieee802_1x_wnm_notif_send(void *eloop_ctx, void *timeout_ctx);
+@@ -674,6 +676,33 @@ int add_sqlite_radius_attr(struct hostapd_data *hapd, struct sta_info *sta,
+ 	return 0;
+ }
+ 
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++#define FAIL -1
++static int get_ap_vlan(char *ifname)
++{
++        char cmd[64] = {0}, buf[32] = {0};
++        FILE *fp;
++        snprintf(cmd, sizeof(cmd), "/usr/sbin/get_vlan.sh %s",ifname);
++        fp = popen(cmd, "r");
++
++        if (NULL == fp) {
++            wpa_printf(MSG_ERROR, " %s: Error in getting vlanid\n",__func__);
++            return FAIL;
++        }
++        if (fgets(buf, sizeof(buf), fp) == NULL) {
++            wpa_printf(MSG_ERROR, "%s: Error in reading vlanid\n",__func__);
++            pclose(fp);
++            return FAIL;
++        }
++        pclose(fp);
++        if (buf[0] == '\0') {
++            wpa_printf(MSG_ERROR, "%s: Error in getting vlanid\n",__func__);
++            return FAIL;
++        }
++        wpa_printf(MSG_DEBUG, "%s: VLAN for interface %s is %d\n",__func__,ifname, atoi(buf));
++        return atoi(buf);
++}
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 
+ void ieee802_1x_encapsulate_radius(struct hostapd_data *hapd,
+ 				   struct sta_info *sta,
+@@ -837,7 +866,46 @@ void ieee802_1x_encapsulate_radius(struct hostapd_data *hapd,
+ 		}
+ 	}
+ #endif /* CONFIG_HS20 */
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++	if (hapd->conf->rdk_greylist  || hapd->conf->connected_building_avp) {
++		u8 secure, snr;
++		u32 ap_vlan;
++		char txtaddr[TXT_MAC_ADDR_LEN] = {'\0'};
++		char managed_guest_val[128] = "cb01";
++
++		secure = (hapd->conf->wpa == 0) ? 1 : 2;
++
++		os_snprintf(txtaddr, sizeof(txtaddr), MACSTR, MAC2STR(sta->addr));
++		snr = greylist_get_client_snr(hapd, txtaddr);
++
++		greylist_get_cmmac();
++
++		ap_vlan = htonl(get_ap_vlan(hapd->conf->iface));
++
++		if (FAIL == ap_vlan) {
++			ap_vlan = htonl(hapd->conf->ap_vlan);
++		}
++		radius_msg_add_comcast(
++			msg, RADIUS_VENDOR_ATTR_COMCAST_NETWORK_TYPE,
++			&secure, 1);
++		radius_msg_add_comcast(
++			msg, RADIUS_VENDOR_ATTR_COMCAST_CM_MAC,
++			cmmac, TXT_MAC_ADDR_LEN - 1);
++		radius_msg_add_comcast(
++			msg, RADIUS_VENDOR_ATTR_COMCAST_AP_VLAN_32,
++			(u8 *)&ap_vlan, 4);
++		radius_msg_add_comcast(
++			msg, RADIUS_VENDOR_ATTR_COMCAST_AP_SNR,
++			&snr, 1);
++		if(hapd->conf->connected_building_avp)
++		{
++				radius_msg_add_comcast(
++				msg, RADIUS_VENDOR_ATTR_COMCAST_CONNECTED_BUILDING,
++				managed_guest_val,strlen(managed_guest_val));
++		}
+ 
++	}
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 	if (radius_client_send(hapd->radius, msg, RADIUS_AUTH, sta->addr) < 0)
+ 		goto fail;
+ 
+@@ -991,6 +1059,10 @@ ieee802_1x_alloc_eapol_sm(struct hostapd_data *hapd, struct sta_info *sta)
+ 		if (wpa_auth_sta_get_pmksa(sta->wpa_sm))
+ 			flags |= EAPOL_SM_FROM_PMKSA_CACHE;
+ 	}
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++	if ((hapd->conf->rdk_greylist || hapd->conf->connected_building_avp) && !hapd->conf->ieee802_1x)
++		flags |= EAPOL_SM_SKIP_EAP;
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 	return eapol_auth_alloc(hapd->eapol_auth, sta->addr, flags,
+ 				sta->wps_ie, sta->p2p_ie, sta,
+ 				sta->identity, sta->radius_cui);
+@@ -1243,6 +1315,16 @@ void ieee802_1x_new_station(struct hostapd_data *hapd, struct sta_info *sta)
+ 		force_1x = 1;
+ 	}
+ #endif /* CONFIG_WPS */
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++	if ((hapd->conf->rdk_greylist || hapd->conf->connected_building_avp) && !hapd->conf->ieee802_1x) {
++		/*
++		 * Need to use IEEE 802.1X/EAPOL state machines for authentication
++		 * in the greylist enabled BSS even if IEEE 802.1x/EAPOL is not
++		 * used.
++		 */
++		force_1x = 1;
++	}
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 
+ 	if (!force_1x && !hapd->conf->ieee802_1x && !hapd->conf->osen) {
+ 		wpa_printf(MSG_DEBUG,
+@@ -1257,7 +1339,7 @@ void ieee802_1x_new_station(struct hostapd_data *hapd, struct sta_info *sta)
+ 
+ 	key_mgmt = wpa_auth_sta_key_mgmt(sta->wpa_sm);
+ 	if (key_mgmt != -1 &&
+-	    (wpa_key_mgmt_wpa_psk(key_mgmt) || key_mgmt == WPA_KEY_MGMT_OWE ||
++	    (wpa_key_mgmt_wpa_psk(key_mgmt) || (key_mgmt == WPA_KEY_MGMT_OWE && !(hapd->conf->rdk_greylist || hapd->conf->connected_building_avp)) ||
+ 	     key_mgmt == WPA_KEY_MGMT_DPP)) {
+ 		wpa_printf(MSG_DEBUG, "IEEE 802.1X: Ignore STA - using PSK");
+ 		/*
+@@ -1268,7 +1350,7 @@ void ieee802_1x_new_station(struct hostapd_data *hapd, struct sta_info *sta)
+ 		return;
+ 	}
+ 
+-	if (!sta->eapol_sm) {
++	if (!sta->eapol_sm ||  (key_mgmt == WPA_KEY_MGMT_OWE && ((hapd->conf->rdk_greylist) || (hapd->conf->connected_building_avp)))) {
+ 		hostapd_logger(hapd, sta->addr, HOSTAPD_MODULE_IEEE8021X,
+ 			       HOSTAPD_LEVEL_DEBUG, "start authentication");
+ 		sta->eapol_sm = ieee802_1x_alloc_eapol_sm(hapd, sta);
+@@ -1299,6 +1381,19 @@ void ieee802_1x_new_station(struct hostapd_data *hapd, struct sta_info *sta)
+ 
+ 	sta->eapol_sm->eap_if->portEnabled = true;
+ 
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++	if ((hapd->conf->rdk_greylist  || hapd->conf->connected_building_avp) && !hapd->conf->ieee802_1x) {
++		/*
++		 * Fake IEEE 802.1X/EAPOL state machines to send
++		 * Radius Access-Request.
++		 */
++		wpa_printf(MSG_DEBUG,
++			   "GREYLIST: Send Radius Access-Request w/o EAP Response");
++		sta->eapol_sm->eap_if->aaaEapResp = true;
++		eapol_auth_step(sta->eapol_sm);
++		return;
++	}
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ #ifdef CONFIG_IEEE80211R_AP
+ 	if (sta->auth_alg == WLAN_AUTH_FT) {
+ 		hostapd_logger(hapd, sta->addr, HOSTAPD_MODULE_IEEE8021X,
+@@ -1382,7 +1477,7 @@ void ieee802_1x_free_station(struct hostapd_data *hapd, struct sta_info *sta)
+ 	eloop_cancel_timeout(ieee802_1x_wnm_notif_send, hapd, sta);
+ #endif /* CONFIG_HS20 */
+ 
+-	if (sta->pending_eapol_rx) {
++	if (sta->pending_eapol_rx && sta->pending_eapol_rx->buf) {
+ 		wpabuf_free(sta->pending_eapol_rx->buf);
+ 		os_free(sta->pending_eapol_rx);
+ 		sta->pending_eapol_rx = NULL;
+@@ -1462,6 +1557,7 @@ static void ieee802_1x_decapsulate_radius(struct hostapd_data *hapd,
+ 		break;
+ 	case EAP_CODE_FAILURE:
+ 		os_strlcpy(buf, "EAP Failure", sizeof(buf));
++		hostapd_drv_radius_eap_failure(hapd, DRV_EAP_FAILURE);
+ 		break;
+ 	default:
+ 		os_strlcpy(buf, "unknown EAP code", sizeof(buf));
+@@ -2029,6 +2125,12 @@ ieee802_1x_receive_auth(struct radius_msg *msg, struct radius_msg *req,
+ 		ieee802_1x_check_hs20(hapd, sta, msg,
+ 				      session_timeout_set ?
+ 				      (int) session_timeout : -1);
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++#ifdef CONFIG_DRIVER_BRCM
++		if ((hapd->conf->rdk_greylist  || hapd->conf->connected_building_avp) && !hapd->conf->ieee802_1x)
++			ieee802_1x_set_sta_authorized(hapd, sta, 1);
++#endif
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 		break;
+ 	case RADIUS_CODE_ACCESS_REJECT:
+ 		sm->eap_if->aaaFail = true;
+@@ -2040,6 +2142,38 @@ ieee802_1x_receive_auth(struct radius_msg *msg, struct radius_msg *req,
+ 				   MACSTR, reason_code, MAC2STR(sta->addr));
+ 			sta->disconnect_reason_code = reason_code;
+ 		}
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++		if (hapd->conf->rdk_greylist) {
++			u8 *reply;
++			size_t replylen;
++			char txtaddr[TXT_MAC_ADDR_LEN];
++
++			wpa_printf(MSG_DEBUG,
++				   "GREYLIST: Access-Reject for "MACSTR, MAC2STR(sta->addr));
++
++			reply = radius_msg_get_vendor_attr(msg, RADIUS_VENDOR_ID_COMCAST,
++					 RADIUS_VENDOR_ATTR_COMCAST_REPLY_MESSAGE,
++					 &replylen);
++			if (reply) {
++				if (os_memcmp_const(reply, "GREYLIST", replylen) == 0) {
++					wpa_printf(MSG_DEBUG,
++						   "RADIUS server indicated GREYLIST in Access-Reject for "
++						   MACSTR, MAC2STR(sta->addr));
++					snprintf(txtaddr, sizeof(txtaddr), MACSTR, MAC2STR(sta->addr));
++                                       // greylist_add(hapd, txtaddr, true);
++
++					sta->disconnect_reason_code = WLAN_RADIUS_GREYLIST_REJECT;
++					if (!hapd->conf->ieee802_1x) {
++						/* For the secure mode, EAPOL SM will handle the disconnect */
++						ap_sta_disconnect(hapd, sta, sta->addr,
++								WLAN_RADIUS_GREYLIST_REJECT);
++					}
++				}
++				os_free(reply);
++			}
++		}
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
++		hostapd_drv_radius_eap_failure(hapd, DRV_RADIUS_ACCESS_REJECT);
+ 		break;
+ 	case RADIUS_CODE_ACCESS_CHALLENGE:
+ 		sm->eap_if->aaaEapReq = true;
+diff --git a/src/ap/ieee802_1x.h b/src/ap/ieee802_1x.h
+index 70dc11afe..aaf0455bd 100644
+--- a/src/ap/ieee802_1x.h
++++ b/src/ap/ieee802_1x.h
+@@ -9,6 +9,9 @@
+ #ifndef IEEE802_1X_H
+ #define IEEE802_1X_H
+ 
++#define DRV_RADIUS_ACCESS_REJECT 1
++#define DRV_EAP_FAILURE 2
++
+ struct hostapd_data;
+ struct sta_info;
+ struct eapol_state_machine;
+diff --git a/src/ap/sta_info.c b/src/ap/sta_info.c
+index c54192612..c4a03378c 100644
+--- a/src/ap/sta_info.c
++++ b/src/ap/sta_info.c
+@@ -206,7 +206,18 @@ void ap_free_sta(struct hostapd_data *hapd, struct sta_info *sta)
+ 
+ 	if (!hapd->iface->driver_ap_teardown &&
+ 	    !(sta->flags & WLAN_STA_PREAUTH)) {
++#ifdef CONFIG_DRIVER_BRCM
++		/* Do not send deauth/disassoc notification back to driver, if it is
++		 * due to driver deauth/disassoc event.
++		 */
++		if (!(sta->flags & WLAN_STA_DRIVER_IND)) {
++			wpa_printf(MSG_DEBUG, "%s %d AP: remove STA " MACSTR
++					, __FUNCTION__, __LINE__, MAC2STR(sta->addr));
++			hostapd_drv_sta_remove(hapd, sta->addr);
++		}
++#else
+ 		hostapd_drv_sta_remove(hapd, sta->addr);
++#endif /* CONFIG_DRIVER_BRCM */
+ 		sta->added_unassoc = 0;
+ 	}
+ 
+@@ -320,7 +331,18 @@ void ap_free_sta(struct hostapd_data *hapd, struct sta_info *sta)
+ 		 */
+ 		if (hapd->iface->driver_ap_teardown &&
+ 		    !(sta->flags & WLAN_STA_PREAUTH)) {
++#ifdef CONFIG_DRIVER_BRCM
++			/* Do not send deauth/disassoc notification back to driver, if it is
++			 * due to driver deauth/disassoc event.
++			 */
++			if (!(sta->flags & WLAN_STA_DRIVER_IND)) {
++				wpa_printf(MSG_DEBUG, "%s %d AP: remove STA " MACSTR
++						, __FUNCTION__, __LINE__, MAC2STR(sta->addr));
++				hostapd_drv_sta_remove(hapd, sta->addr);
++			}
++#else
+ 			hostapd_drv_sta_remove(hapd, sta->addr);
++#endif /* CONFIG_DRIVER_BRCM */
+ 			sta->added_unassoc = 0;
+ 		}
+ 		vlan_remove_dynamic(hapd, sta->vlan_id_bound);
+@@ -414,6 +436,8 @@ void ap_free_sta(struct hostapd_data *hapd, struct sta_info *sta)
+ 	forced_memzero(sta->last_tk, WPA_TK_MAX_LEN);
+ #endif /* CONFIG_TESTING_OPTIONS */
+ 
++	os_free(sta->assoc_req);
++
+ 	os_free(sta);
+ }
+ 
+diff --git a/src/ap/sta_info.h b/src/ap/sta_info.h
+index af8f171b2..5abac67e3 100644
+--- a/src/ap/sta_info.h
++++ b/src/ap/sta_info.h
+@@ -20,6 +20,9 @@
+ /* STA flags */
+ #define WLAN_STA_AUTH BIT(0)
+ #define WLAN_STA_ASSOC BIT(1)
++#ifdef CONFIG_DRIVER_BRCM
++#define WLAN_STA_DRIVER_IND BIT(2)
++#endif /* CONFIG_DRIVER_BRCM */
+ #define WLAN_STA_AUTHORIZED BIT(5)
+ #define WLAN_STA_PENDING_POLL BIT(6) /* pending activity poll not ACKed */
+ #define WLAN_STA_SHORT_PREAMBLE BIT(7)
+@@ -333,6 +336,8 @@ struct sta_info {
+ #ifdef CONFIG_PASN
+ 	struct pasn_data *pasn;
+ #endif /* CONFIG_PASN */
++	u8 *assoc_req;
++	size_t assoc_req_len;
+ };
+ 
+ 
+diff --git a/src/ap/utils.c b/src/ap/utils.c
+index bedad6eb0..35e537caa 100644
+--- a/src/ap/utils.c
++++ b/src/ap/utils.c
+@@ -93,6 +93,10 @@ void hostapd_prune_associations(struct hostapd_data *hapd, const u8 *addr)
+ 	struct prune_data data;
+ 	data.hapd = hapd;
+ 	data.addr = addr;
++    if(hapd && hapd->iface == NULL) {
++            wpa_printf(MSG_ERROR, "%s:%d hapd->iface is NULL", __func__, __LINE__);
++            return;
++    }
+ 	if (hapd->iface->interfaces &&
+ 	    hapd->iface->interfaces->for_each_interface)
+ 		hapd->iface->interfaces->for_each_interface(
+diff --git a/src/ap/wpa_auth.c b/src/ap/wpa_auth.c
+index 0cf603c10..2ad3ecadf 100644
+--- a/src/ap/wpa_auth.c
++++ b/src/ap/wpa_auth.c
+@@ -32,6 +32,9 @@
+ #include "pmksa_cache_auth.h"
+ #include "wpa_auth_i.h"
+ #include "wpa_auth_ie.h"
++#if defined(CONFIG_DRIVER_BRCM) && defined(CONFIG_DRIVER_BRCM_CEVENT)
++#include "ce_shared.h"
++#endif /* CONFIG_DRIVER_BRCM && CONFIG_DRIVER_BRCM_CEVENT */
+ 
+ #define STATE_MACHINE_DATA struct wpa_state_machine
+ #define STATE_MACHINE_DEBUG_PREFIX "WPA"
+@@ -78,6 +81,14 @@ static const int dot11RSNAConfigPMKLifetime = 43200;
+ static const int dot11RSNAConfigPMKReauthThreshold = 70;
+ static const int dot11RSNAConfigSATimeout = 60;
+ 
++#if defined(CONFIG_DRIVER_BRCM) && defined(CONFIG_DRIVER_BRCM_CEVENT)
++static inline char* wpa_auth_get_ifname(struct wpa_authenticator *wpa_auth)
++{
++	if (wpa_auth->cb->get_ifname)
++		return wpa_auth->cb->get_ifname(wpa_auth->cb_ctx);
++	return 0;
++}
++#endif /* CONFIG_DRIVER_BRCM && CONFIG_DRIVER_BRCM_CEVENT */
+ 
+ static inline int wpa_auth_mic_failure_report(
+ 	struct wpa_authenticator *wpa_auth, const u8 *addr)
+@@ -257,6 +268,11 @@ void wpa_auth_vlogger(struct wpa_authenticator *wpa_auth, const u8 *addr,
+ 	int maxlen;
+ 	va_list ap;
+ 
++    if (wpa_auth == NULL)
++        return;
++    if (wpa_auth->cb == NULL)
++        return;
++
+ 	if (!wpa_auth->cb->logger)
+ 		return;
+ 
+@@ -650,6 +666,9 @@ wpa_auth_sta_init(struct wpa_authenticator *wpa_auth, const u8 *addr,
+ {
+ 	struct wpa_state_machine *sm;
+ 
++	if(!wpa_auth)
++		return NULL;
++
+ 	if (wpa_auth->group->wpa_group_state == WPA_GROUP_FATAL_FAILURE)
+ 		return NULL;
+ 
+@@ -1026,6 +1045,9 @@ void wpa_receive(struct wpa_authenticator *wpa_auth,
+ 	const u8 *key_data;
+ 	size_t keyhdrlen, mic_len;
+ 	u8 *mic;
++#if defined(CONFIG_DRIVER_BRCM) && defined(CONFIG_DRIVER_BRCM_CEVENT)
++	char *ifname = NULL;
++#endif /* CONFIG_DRIVER_BRCM && CONFIG_DRIVER_BRCM_CEVENT */
+ 
+ 	if (!wpa_auth || !wpa_auth->conf.wpa || !sm)
+ 		return;
+@@ -1097,7 +1119,9 @@ void wpa_receive(struct wpa_authenticator *wpa_auth,
+ 		wpa_printf(MSG_DEBUG, "WPA: Ignore SMK message");
+ 		return;
+ 	}
+-
++#if defined(CONFIG_DRIVER_BRCM) && defined(CONFIG_DRIVER_BRCM_CEVENT)
++	ifname = wpa_auth_get_ifname(wpa_auth);
++#endif /* CONFIG_DRIVER_BRCM && CONFIG_DRIVER_BRCM_CEVENT */
+ 	if (key_info & WPA_KEY_INFO_REQUEST) {
+ 		msg = REQUEST;
+ 		msgtxt = "Request";
+@@ -1109,9 +1133,17 @@ void wpa_receive(struct wpa_authenticator *wpa_auth,
+ 		    key_data_length == AES_BLOCK_SIZE)) {
+ 		msg = PAIRWISE_4;
+ 		msgtxt = "4/4 Pairwise";
++#if defined(CONFIG_DRIVER_BRCM) && defined(CONFIG_DRIVER_BRCM_CEVENT)
++		CE_SEND_CEVENT_A2C_EXT(ifname, (struct ether_addr *)sm->addr, 0, 0, CEVENT_ST_HOSTAPD,
++			CEVENT_A2C_MT_M4_RX, CEVENT_FRAME_DIR_RX, NULL, 0);
++#endif /* CONFIG_DRIVER_BRCM && CONFIG_DRIVER_BRCM_CEVENT */
+ 	} else {
+ 		msg = PAIRWISE_2;
+ 		msgtxt = "2/4 Pairwise";
++#if defined(CONFIG_DRIVER_BRCM) && defined(CONFIG_DRIVER_BRCM_CEVENT)
++		CE_SEND_CEVENT_A2C_EXT(ifname, (struct ether_addr *)sm->addr, 0, 0, CEVENT_ST_HOSTAPD,
++			CEVENT_A2C_MT_M2_RX, CEVENT_FRAME_DIR_RX, NULL, 0);
++#endif /* CONFIG_DRIVER_BRCM && CONFIG_DRIVER_BRCM_CEVENT */
+ 	}
+ 
+ 	if (msg == REQUEST || msg == PAIRWISE_2 || msg == PAIRWISE_4 ||
+@@ -2196,6 +2228,9 @@ SM_STATE(WPA_PTK, PTKSTART)
+ 	u8 buf[2 + RSN_SELECTOR_LEN + PMKID_LEN], *pmkid = NULL;
+ 	size_t pmkid_len = 0;
+ 
++#if defined(CONFIG_DRIVER_BRCM) && defined(CONFIG_DRIVER_BRCM_CEVENT)
++	char *ifname = NULL;
++#endif /* CONFIG_DRIVER_BRCM && CONFIG_DRIVER_BRCM_CEVENT */
+ 	SM_ENTRY_MA(WPA_PTK, PTKSTART, wpa_ptk);
+ 	sm->PTKRequest = false;
+ 	sm->TimeoutEvt = false;
+@@ -2208,7 +2243,11 @@ SM_STATE(WPA_PTK, PTKSTART)
+ 		 * immediately following this. */
+ 		return;
+ 	}
+-
++#if defined(CONFIG_DRIVER_BRCM) && defined(CONFIG_DRIVER_BRCM_CEVENT)
++	ifname = wpa_auth_get_ifname(sm->wpa_auth);
++	CE_SEND_CEVENT_A2C_EXT(ifname, (struct ether_addr *)sm->addr, 0, 0, CEVENT_ST_HOSTAPD,
++		CEVENT_A2C_MT_M1_TX, CEVENT_FRAME_DIR_TX, NULL, 0);
++#endif /* CONFIG_DRIVER_BRCM && CONFIG_DRIVER_BRCM_CEVENT */
+ 	wpa_auth_logger(sm->wpa_auth, sm->addr, LOGGER_DEBUG,
+ 			"sending 1/4 msg of 4-Way Handshake");
+ 	/*
+@@ -3411,6 +3450,9 @@ SM_STATE(WPA_PTK, PTKINITNEGOTIATING)
+ 	u8 hdr[2];
+ 	struct wpa_auth_config *conf = &sm->wpa_auth->conf;
+ 
++#if defined(CONFIG_DRIVER_BRCM) && defined(CONFIG_DRIVER_BRCM_CEVENT)
++	char *ifname = NULL;
++#endif /* CONFIG_DRIVER_BRCM && CONFIG_DRIVER_BRCM_CEVENT */
+ 	SM_ENTRY_MA(WPA_PTK, PTKINITNEGOTIATING, wpa_ptk);
+ 	sm->TimeoutEvt = false;
+ 
+@@ -3463,6 +3505,11 @@ SM_STATE(WPA_PTK, PTKINITNEGOTIATING)
+ 		wpa_ie = wpa_ie_buf;
+ 	}
+ #endif /* CONFIG_TESTING_OPTIONS */
++#if defined(CONFIG_DRIVER_BRCM) && defined(CONFIG_DRIVER_BRCM_CEVENT)
++	ifname = wpa_auth_get_ifname(sm->wpa_auth);
++	CE_SEND_CEVENT_A2C_EXT(ifname, (struct ether_addr *)sm->addr, 0, 0, CEVENT_ST_HOSTAPD,
++			CEVENT_A2C_MT_M3_TX, CEVENT_FRAME_DIR_TX, NULL, 0);
++#endif /* CONFIG_DRIVER_BRCM && CONFIG_DRIVER_BRCM_CEVENT */
+ 	wpa_auth_logger(sm->wpa_auth, sm->addr, LOGGER_DEBUG,
+ 			"sending 3/4 msg of 4-Way Handshake");
+ 	if (sm->wpa == WPA_VERSION_WPA2) {
+diff --git a/src/ap/wpa_auth.h b/src/ap/wpa_auth.h
+index d2a36006a..07c51c4f3 100644
+--- a/src/ap/wpa_auth.h
++++ b/src/ap/wpa_auth.h
+@@ -267,7 +267,9 @@ struct wpa_auth_config {
+ #ifdef CONFIG_DPP2
+ 	int dpp_pfs;
+ #endif /* CONFIG_DPP2 */
+-
++#ifdef CONFIG_DRIVER_BRCM
++	int spp_amsdu;
++#endif /* CONFIG_DRIVER_BRCM */
+ 	/*
+ 	 * If set Key Derivation Key should be derived as part of PMK to
+ 	 * PTK derivation regardless of advertised capabilities.
+@@ -350,6 +352,9 @@ struct wpa_auth_callbacks {
+ #ifdef CONFIG_MESH
+ 	int (*start_ampe)(void *ctx, const u8 *sta_addr);
+ #endif /* CONFIG_MESH */
++#if defined(CONFIG_DRIVER_BRCM) && defined(CONFIG_DRIVER_BRCM_CEVENT)
++	char* (*get_ifname)(void *ctx);
++#endif /* CONFIG_DRIVER_BRCM && CONFIG_DRIVER_BRCM_CEVENT */
+ };
+ 
+ struct wpa_authenticator * wpa_init(const u8 *addr,
+diff --git a/src/ap/wpa_auth_glue.c b/src/ap/wpa_auth_glue.c
+index 50efc2c28..aedac415e 100644
+--- a/src/ap/wpa_auth_glue.c
++++ b/src/ap/wpa_auth_glue.c
+@@ -210,6 +210,9 @@ static void hostapd_wpa_auth_conf(struct hostapd_bss_config *conf,
+ #ifdef CONFIG_DPP2
+ 	wconf->dpp_pfs = conf->dpp_pfs;
+ #endif /* CONFIG_DPP2 */
++#ifdef CONFIG_DRIVER_BRCM
++	wconf->spp_amsdu = conf->spp_amsdu;
++#endif /* CONFIG_DRIVER_BRCM */
+ #ifdef CONFIG_PASN
+ #ifdef CONFIG_TESTING_OPTIONS
+ 	wconf->force_kdk_derivation = conf->force_kdk_derivation;
+@@ -268,6 +271,7 @@ static void hostapd_wpa_auth_psk_failure_report(void *ctx, const u8 *addr)
+ 	struct hostapd_data *hapd = ctx;
+ 	wpa_msg(hapd->msg_ctx, MSG_INFO, AP_STA_POSSIBLE_PSK_MISMATCH MACSTR,
+ 		MAC2STR(addr));
++	hostapd_drv_sta_notify_deauth(hapd, addr, WLAN_REASON_PREV_AUTH_NOT_VALID);
+ }
+ 
+ 
+@@ -758,6 +762,29 @@ static struct eth_p_oui_ctx * hostapd_wpa_get_oui(struct hostapd_data *hapd,
+ 		return NULL;
+ 	}
+ }
++
++#ifdef CONFIG_DRIVER_BRCM
++static struct eth_p_oui_ctx * hostapd_wpa_get_lo_oui(struct hostapd_data *hapd,
++						  u8 oui_suffix)
++{
++	switch (oui_suffix) {
++#ifdef CONFIG_IEEE80211R_AP
++	case FT_PACKET_R0KH_R1KH_PULL:
++		return hapd->lo_oui_pull;
++	case FT_PACKET_R0KH_R1KH_RESP:
++		return hapd->lo_oui_resp;
++	case FT_PACKET_R0KH_R1KH_PUSH:
++		return hapd->lo_oui_push;
++	case FT_PACKET_R0KH_R1KH_SEQ_REQ:
++		return hapd->lo_oui_sreq;
++	case FT_PACKET_R0KH_R1KH_SEQ_RESP:
++		return hapd->lo_oui_sresp;
++#endif /* CONFIG_IEEE80211R_AP */
++	default:
++		return NULL;
++	}
++}
++#endif /* CONFIG_DRIVER_BRCM */
+ #endif /* CONFIG_ETH_P_OUI */
+ 
+ 
+@@ -905,6 +932,16 @@ static int hostapd_wpa_auth_send_oui(void *ctx, const u8 *dst, u8 oui_suffix,
+ 			return data_len;
+ 	}
+ #endif /* CONFIG_IEEE80211R_AP */
++#ifdef CONFIG_DRIVER_BRCM
++	/* Send l2 packet on loopback socket as well */
++	if (hapd->iconf->ft_rrb_lo_sock) {
++		oui_ctx = hostapd_wpa_get_lo_oui(hapd, oui_suffix);
++		if (!oui_ctx)
++			return -1;
++
++		eth_p_oui_send(oui_ctx, hapd->own_addr, dst, data, data_len);
++	}
++#endif /* CONFIG_DRIVER_BRCM */
+ 
+ 	oui_ctx = hostapd_wpa_get_oui(hapd, oui_suffix);
+ 	if (!oui_ctx)
+@@ -1353,6 +1390,15 @@ static int hostapd_wpa_auth_get_session_timeout(void *ctx, const u8 *sta_addr)
+ 	return (remaining.sec > 0) ? remaining.sec : 1;
+ }
+ 
++#if defined(CONFIG_DRIVER_BRCM) && defined(CONFIG_DRIVER_BRCM_CEVENT)
++static char* hostapd_wpa_auth_get_ifname(void *ctx)
++{
++	struct hostapd_data *hapd = ctx;
++	if (hapd && hapd->conf)
++		return hapd->conf->iface;
++	return NULL;
++}
++#endif /* CONFIG_DRIVER_BRCM && CONFIG_DRIVER_BRCM_CEVENT */
+ 
+ static void hostapd_rrb_receive(void *ctx, const u8 *src_addr, const u8 *buf,
+ 				size_t len)
+@@ -1433,6 +1479,43 @@ static int hostapd_wpa_register_ft_oui(struct hostapd_data *hapd,
+ 	return 0;
+ }
+ 
++#ifdef CONFIG_DRIVER_BRCM
++static int hostapd_wpa_register_ft_lo_oui(struct hostapd_data *hapd,
++				       const char *ft_iface)
++{
++	hapd->lo_oui_pull = eth_p_oui_register(hapd, ft_iface,
++					    FT_PACKET_R0KH_R1KH_PULL,
++					    hostapd_rrb_oui_receive, hapd);
++	if (!hapd->lo_oui_pull)
++		return -1;
++
++	hapd->lo_oui_resp = eth_p_oui_register(hapd, ft_iface,
++					    FT_PACKET_R0KH_R1KH_RESP,
++					    hostapd_rrb_oui_receive, hapd);
++	if (!hapd->lo_oui_resp)
++		return -1;
++
++	hapd->lo_oui_push = eth_p_oui_register(hapd, ft_iface,
++					    FT_PACKET_R0KH_R1KH_PUSH,
++					    hostapd_rrb_oui_receive, hapd);
++	if (!hapd->lo_oui_push)
++		return -1;
++
++	hapd->lo_oui_sreq = eth_p_oui_register(hapd, ft_iface,
++					    FT_PACKET_R0KH_R1KH_SEQ_REQ,
++					    hostapd_rrb_oui_receive, hapd);
++	if (!hapd->lo_oui_sreq)
++		return -1;
++
++	hapd->lo_oui_sresp = eth_p_oui_register(hapd, ft_iface,
++					     FT_PACKET_R0KH_R1KH_SEQ_RESP,
++					     hostapd_rrb_oui_receive, hapd);
++	if (!hapd->lo_oui_sresp)
++		return -1;
++
++	return 0;
++}
++#endif /* CONFIG_DRIVER_BRCM */
+ 
+ static void hostapd_wpa_unregister_ft_oui(struct hostapd_data *hapd)
+ {
+@@ -1447,6 +1530,21 @@ static void hostapd_wpa_unregister_ft_oui(struct hostapd_data *hapd)
+ 	eth_p_oui_unregister(hapd->oui_sresp);
+ 	hapd->oui_sresp = NULL;
+ }
++#ifdef CONFIG_DRIVER_BRCM
++static void hostapd_wpa_unregister_ft_lo_oui(struct hostapd_data *hapd)
++{
++	eth_p_oui_unregister(hapd->lo_oui_pull);
++	hapd->lo_oui_pull = NULL;
++	eth_p_oui_unregister(hapd->lo_oui_resp);
++	hapd->lo_oui_resp = NULL;
++	eth_p_oui_unregister(hapd->lo_oui_push);
++	hapd->lo_oui_push = NULL;
++	eth_p_oui_unregister(hapd->lo_oui_sreq);
++	hapd->lo_oui_sreq = NULL;
++	eth_p_oui_unregister(hapd->lo_oui_sresp);
++	hapd->lo_oui_sresp = NULL;
++}
++#endif /* CONFIG_DRIVER_BRCM */
+ #endif /* CONFIG_IEEE80211R_AP */
+ 
+ 
+@@ -1513,6 +1611,9 @@ int hostapd_setup_wpa(struct hostapd_data *hapd)
+ #ifndef CONFIG_NO_RADIUS
+ 		.request_radius_psk = hostapd_request_radius_psk,
+ #endif /* CONFIG_NO_RADIUS */
++#if defined(CONFIG_DRIVER_BRCM) && defined(CONFIG_DRIVER_BRCM_CEVENT)
++		.get_ifname = hostapd_wpa_auth_get_ifname,
++#endif /* CONFIG_DRIVER_BRCM && CONFIG_DRIVER_BRCM_CEVENT */
+ 	};
+ 	const u8 *wpa_ie;
+ 	size_t wpa_ie_len;
+@@ -1607,6 +1708,15 @@ int hostapd_setup_wpa(struct hostapd_data *hapd)
+ 				   "Failed to open ETH_P_OUI interface");
+ 			return -1;
+ 		}
++#ifdef CONFIG_DRIVER_BRCM
++		/* create loopback socket for FT OUI communication */
++		if (hapd->iconf->ft_rrb_lo_sock) {
++			if (hostapd_wpa_register_ft_lo_oui(hapd, "lo")) {
++				wpa_printf(MSG_ERROR,
++					   "Failed to open ETH_P_OUI loopback interface");
++			}
++		}
++#endif /* CONFIG_DRIVER_BRCM */
+ 	}
+ #endif /* CONFIG_IEEE80211R_AP */
+ 
+@@ -1657,6 +1767,12 @@ void hostapd_deinit_wpa(struct hostapd_data *hapd)
+ 	l2_packet_deinit(hapd->l2);
+ 	hapd->l2 = NULL;
+ 	hostapd_wpa_unregister_ft_oui(hapd);
++#ifdef CONFIG_DRIVER_BRCM
++	/* Unregister loopback socket created for FT OUI communication */
++	if (hapd->iconf->ft_rrb_lo_sock) {
++		hostapd_wpa_unregister_ft_lo_oui(hapd);
++	}
++#endif /* CONFIG_DRIVER_BRCM */
+ #endif /* CONFIG_IEEE80211R_AP */
+ 
+ #ifdef CONFIG_TESTING_OPTIONS
+diff --git a/src/ap/wpa_auth_ie.c b/src/ap/wpa_auth_ie.c
+index 524922e4e..7d6b19c73 100644
+--- a/src/ap/wpa_auth_ie.c
++++ b/src/ap/wpa_auth_ie.c
+@@ -103,6 +103,14 @@ static u16 wpa_own_rsn_capab(struct wpa_auth_config *conf)
+ 		if (conf->ieee80211w == MGMT_FRAME_PROTECTION_REQUIRED)
+ 			capab |= WPA_CAPABILITY_MFPR;
+ 	}
++#ifdef CONFIG_DRIVER_BRCM
++	if (conf->spp_amsdu != 0) {
++		capab |= WPA_CAPABILITY_SPP_A_MSDU_CAPABLE;
++		if (conf->spp_amsdu == 2) {
++			capab |= WPA_CAPABILITY_SPP_A_MSDU_REQUIRED;
++		}
++	}
++#endif /* CONFIG_DRIVER_BRCM */
+ #ifdef CONFIG_OCV
+ 	if (conf->ocv)
+ 		capab |= WPA_CAPABILITY_OCVC;
+@@ -481,9 +489,15 @@ static u8 * wpa_write_osen(struct wpa_auth_config *conf, u8 *eid)
+ 
+ int wpa_auth_gen_wpa_ie(struct wpa_authenticator *wpa_auth)
+ {
++#ifdef CONFIG_DRIVER_BRCM
++	u8 *pos, buf[256];
++#else
+ 	u8 *pos, buf[128];
++#endif /* CONFIG_DRIVER_BRCM */
+ 	int res;
+-
++#ifdef CONFIG_DRIVER_BRCM
++	int use_sha384;
++#endif
+ #ifdef CONFIG_TESTING_OPTIONS
+ 	if (wpa_auth->conf.own_ie_override_len) {
+ 		wpa_hexdump(MSG_DEBUG, "WPA: Forced own IE(s) for testing",
+@@ -525,6 +539,23 @@ int wpa_auth_gen_wpa_ie(struct wpa_authenticator *wpa_auth)
+ 		if (res < 0)
+ 			return res;
+ 		pos += res;
++#ifdef CONFIG_DRIVER_BRCM
++		if (wpa_auth->conf.r0_key_holder_len == 0) {
++			os_free(wpa_auth->wpa_ie);
++			wpa_auth->wpa_ie = NULL;
++			return -1;
++		}
++
++		wpa_printf(MSG_DEBUG, "Writing FT IE r0kh_id_len %d\n",  wpa_auth->conf.r0_key_holder_len);
++		use_sha384 = wpa_key_mgmt_sha384(wpa_auth->conf.wpa_key_mgmt);
++		res = wpa_write_ftie(&wpa_auth->conf, use_sha384, wpa_auth->conf.r0_key_holder,
++		   wpa_auth->conf.r0_key_holder_len, NULL, NULL,
++		   pos, buf + sizeof(buf) - pos, NULL, 0, 0);
++
++		if (res < 0)
++			return res;
++		pos += res;
++#endif /* CONFIG_DRIVER_BRCM */
+ 	}
+ #endif /* CONFIG_IEEE80211R_AP */
+ 	if (wpa_auth->conf.wpa & WPA_PROTO_WPA) {
+diff --git a/src/ap/wps_hostapd.c b/src/ap/wps_hostapd.c
+index aacfa3372..b63fb35d4 100644
+--- a/src/ap/wps_hostapd.c
++++ b/src/ap/wps_hostapd.c
+@@ -451,6 +451,122 @@ static int hapd_wps_reconfig_in_memory(struct hostapd_data *hapd,
+ 	return 0;
+ }
+ 
++#ifdef CONFIG_DRIVER_BRCM
++static void hapd_wps_write_creds_to_file(FILE *nconf, struct hostapd_data *hapd,
++                const struct wps_credential *cred)
++{
++        int wpa;
++        int i;
++        int sae = 0;
++
++        fprintf(nconf, "# WPS configuration - START\n");
++
++        fprintf(nconf, "wps_state=2\n");
++
++        if (is_hex(cred->ssid, cred->ssid_len)) {
++                fprintf(nconf, "ssid2=");
++                for (i = 0; i < cred->ssid_len; i++)
++                        fprintf(nconf, "%02x", cred->ssid[i]);
++                fprintf(nconf, "\n");
++        } else {
++                fprintf(nconf, "ssid=");
++                for (i = 0; i < cred->ssid_len; i++)
++                        fputc(cred->ssid[i], nconf);
++                fprintf(nconf, "\n");
++        }
++
++        if ((cred->auth_type & (WPS_AUTH_WPA2 | WPS_AUTH_WPA2PSK)) &&
++            (cred->auth_type & (WPS_AUTH_WPA | WPS_AUTH_WPAPSK)))
++                wpa = 3;
++        else if (cred->auth_type & (WPS_AUTH_WPA2 | WPS_AUTH_WPA2PSK))
++                wpa = 2;
++        else if (cred->auth_type & (WPS_AUTH_WPA | WPS_AUTH_WPAPSK))
++                wpa = 1;
++        else
++                wpa = 0;
++
++        if (wpa) {
++                char *prefix;
++                if (cred->auth_type & WPS_AUTH_WPA2PSK
++                        /* Sae needs credential in passphrase-form */
++                        && (cred->key_len >= 8 && cred->key_len < 64)
++                        && hapd->conf->wps_cred_add_sae) {
++                        /* wpa needs to be set to 2 for transition mode (WPA2-PSK + WPA3-SAE) */
++                        sae = 1;
++                        wpa = 2;
++                }
++
++                fprintf(nconf, "wpa=%d\n", wpa);
++
++                fprintf(nconf, "wpa_key_mgmt=");
++                prefix = "";
++                if (cred->auth_type & (WPS_AUTH_WPA2 | WPS_AUTH_WPA)) {
++                        fprintf(nconf, "WPA-EAP");
++                        prefix = " ";
++                }
++                if (cred->auth_type & (WPS_AUTH_WPA2PSK | WPS_AUTH_WPAPSK)) {
++                        fprintf(nconf, "%sWPA-PSK", prefix);
++                        prefix=" ";
++                }
++                if (sae)
++                        fprintf(nconf, "%sSAE", prefix);
++
++                fprintf(nconf, "\n");
++
++                /* ieee80211w may setup as 0 */
++                if (sae && hapd->conf->ieee80211w == NO_MGMT_FRAME_PROTECTION) {
++                        fprintf(nconf, "ieee80211w=%d\n",
++                                MGMT_FRAME_PROTECTION_OPTIONAL);
++                } else {
++                        /* fill current setting */
++                        fprintf(nconf, "ieee80211w=%d\n", hapd->conf->ieee80211w);
++                }
++
++                /* asumme sae_require_mfp is always set when wps_cred_add_sae set */
++
++                fprintf(nconf, "wpa_pairwise=");
++                prefix = "";
++                if (cred->encr_type & WPS_ENCR_AES) {
++                        if (hapd->iconf->hw_mode == HOSTAPD_MODE_IEEE80211AD)
++                                fprintf(nconf, "GCMP");
++                        else
++                                fprintf(nconf, "CCMP");
++
++                        prefix = " ";
++                }
++                if (!sae && cred->encr_type & WPS_ENCR_TKIP) {
++                        fprintf(nconf, "%sTKIP", prefix);
++                }
++                fprintf(nconf, "\n");
++
++                if (cred->key_len >= 8 && cred->key_len < 64) {
++                        fprintf(nconf, "wpa_passphrase=");
++                        for (i = 0; i < cred->key_len; i++)
++                                fputc(cred->key[i], nconf);
++                        fprintf(nconf, "\n");
++                } else if (cred->key_len == 64) {
++                        fprintf(nconf, "wpa_psk=");
++                        for (i = 0; i < cred->key_len; i++)
++                                fputc(cred->key[i], nconf);
++                        fprintf(nconf, "\n");
++                } else {
++                        wpa_printf(MSG_WARNING, "WPS: Invalid key length %lu "
++                                   "for WPA/WPA2",
++                                   (unsigned long) cred->key_len);
++                }
++
++                fprintf(nconf, "auth_algs=1\n");
++        } else {
++                /*
++                 * WPS 2.0 does not allow WEP to be configured, so no need to
++                 * process that option here either.
++                 */
++                fprintf(nconf, "auth_algs=1\n");
++        }
++
++        fprintf(nconf, "# WPS configuration - END\n");
++}
++#endif  /* CONFIG_DRIVER_BRCM */
+ 
+ static int hapd_wps_cred_cb(struct hostapd_data *hapd, void *ctx)
+ {
+@@ -463,6 +579,10 @@ static int hapd_wps_cred_cb(struct hostapd_data *hapd, void *ctx)
+ 	int wpa;
+ 	int pmf_changed = 0;
+ 
++#ifdef CONFIG_DRIVER_BRCM
++        char ifr_token[32], bss_token[32];
++        int bss_found, wps_cred_updated_in_newconf, bss_token_len, ifr_token_len;
++#endif  /* CONFIG_DRIVER_BRCM */
+ 	if (hapd->wps == NULL)
+ 		return 0;
+ 
+@@ -552,7 +672,52 @@ static int hapd_wps_cred_cb(struct hostapd_data *hapd, void *ctx)
+ 		fclose(oconf);
+ 		return -1;
+ 	}
+-
++#ifdef CONFIG_DRIVER_BRCM
++        os_snprintf(ifr_token, sizeof(ifr_token), "interface=%s", hapd->conf->iface);
++        ifr_token_len = strlen(ifr_token);
++        os_snprintf(bss_token, sizeof(bss_token), "bss=%s", hapd->conf->iface);
++        bss_token_len = strlen(bss_token);
++        bss_found = wps_cred_updated_in_newconf = 0;
++        multi_bss = 0;
++        while (fgets(buf, sizeof(buf), oconf)) {
++                /* This is to handle the case for multiple bss lets say we have 3 bss enabled bss1,
++                 * bss2 and bss3. Wps running on bss2 should not update the settings of bss3.
++                 */
++                if (bss_found && os_strncmp(buf, "bss=", 4) == 0) {
++                        multi_bss = 1;
++                }
++
++                /* Find the bss entry which needs to be updated */
++                if (!bss_found && (os_strncmp(buf, bss_token, bss_token_len) == 0 ||
++                        os_strncmp(buf, ifr_token, ifr_token_len) == 0)) {
++                        bss_found = 1;
++                }
++
++                if (bss_found && !multi_bss &&
++                    (str_starts(buf, "ssid=") ||
++                     str_starts(buf, "ssid2=") ||
++                     str_starts(buf, "auth_algs=") ||
++                     str_starts(buf, "wep_default_key=") ||
++                     str_starts(buf, "wep_key") ||
++                     str_starts(buf, "wps_state=") ||
++                     str_starts(buf, "wpa=") ||
++                     str_starts(buf, "wpa_psk=") ||
++                     str_starts(buf, "wpa_pairwise=") ||
++                     str_starts(buf, "rsn_pairwise=") ||
++                     str_starts(buf, "wpa_key_mgmt=") ||
++                     str_starts(buf, "ieee80211w=") ||
++                     str_starts(buf, "wpa_passphrase="))) {
++                        fprintf(nconf, "#WPS# %s", buf);
++                } else
++                        fprintf(nconf, "%s", buf);
++
++                /* Write the wps credentials in new conf file */
++                if (bss_found && !wps_cred_updated_in_newconf) {
++                        hapd_wps_write_creds_to_file(nconf, hapd, cred);
++                        wps_cred_updated_in_newconf = 1;
++                }
++        }
++#else   /* !CONFIG_DRIVER_BRCM */
+ 	fprintf(nconf, "# WPS configuration - START\n");
+ 
+ 	fprintf(nconf, "wps_state=2\n");
+@@ -687,6 +852,7 @@ static int hapd_wps_cred_cb(struct hostapd_data *hapd, void *ctx)
+ 		} else
+ 			fprintf(nconf, "%s", buf);
+ 	}
++#endif  /* CONFIG_DRIVER_BRCM */
+ 
+ 	fclose(nconf);
+ 	fclose(oconf);
+@@ -872,14 +1038,28 @@ static void hostapd_wps_event_fail(struct hostapd_data *hapd,
+ 
+ 	if (fail->error_indication > 0 &&
+ 	    fail->error_indication < NUM_WPS_EI_VALUES) {
++#ifdef CONFIG_DRIVER_BRCM
++            wpa_msg(hapd->msg_ctx, MSG_INFO,
++                    WPS_EVENT_FAIL "msg=%d peer_macaddr="MACSTR" config_error=%d "
++                    "reason=%d (%s)", fail->msg, MAC2STR(fail->peer_macaddr),
++                    fail->config_error, fail->error_indication,
++                    wps_ei_str(fail->error_indication));
++#else
+ 		wpa_msg(hapd->msg_ctx, MSG_INFO,
+ 			WPS_EVENT_FAIL "msg=%d config_error=%d reason=%d (%s)",
+ 			fail->msg, fail->config_error, fail->error_indication,
+ 			wps_ei_str(fail->error_indication));
++#endif	/* CONFIG_DRIVER_BRCM */
+ 	} else {
++#ifdef CONFIG_DRIVER_BRCM
++		wpa_msg(hapd->msg_ctx, MSG_INFO,
++			WPS_EVENT_FAIL "msg=%d peer_macaddr="MACSTR" config_error=%d",
++			fail->msg, MAC2STR(fail->peer_macaddr), fail->config_error);
++#else
+ 		wpa_msg(hapd->msg_ctx, MSG_INFO,
+ 			WPS_EVENT_FAIL "msg=%d config_error=%d",
+ 			fail->msg, fail->config_error);
++#endif  /* CONFIG_DRIVER_BRCM */
+ 	}
+ }
+ 
+@@ -937,6 +1117,10 @@ static void hostapd_wps_event_cb(void *ctx, enum wps_event event,
+ 	}
+ 	if (hapd->wps_event_cb)
+ 		hapd->wps_event_cb(hapd->wps_event_cb_ctx, event, data);
++
++#ifdef RDK_ONEWIFI
++	hostapd_drv_wps_event_notify_cb(hapd, event, data);
++#endif //RDK_ONEWIFI
+ }
+ 
+ 
+@@ -1294,7 +1478,16 @@ int hostapd_init_wps(struct hostapd_data *hapd,
+ 
+ 	wps->ap_settings = conf->ap_settings;
+ 	wps->ap_settings_len = conf->ap_settings_len;
+-
++#ifdef CONFIG_DRIVER_BRCM_MAP
++    wps->map = conf->map;
++    os_memset(&wps->bh_creds, 0, sizeof(wps->bh_creds));
++    wps->bh_creds.ssid_len = conf->map_bh_ssid_len;
++    os_memcpy(wps->bh_creds.ssid, conf->map_bh_ssid, wps->bh_creds.ssid_len);
++    wps->bh_creds.auth_type = conf->map_bh_auth;
++    wps->bh_creds.encr_type = conf->map_bh_encr;
++    wps->bh_creds.key_len = conf->map_bh_psk_len;
++    os_memcpy(wps->bh_creds.key, conf->map_bh_psk, wps->bh_creds.key_len);
++#endif  /* CONFIG_DRIVER_BRCM_MAP */
+ 	cfg.new_psk_cb = hostapd_wps_new_psk_cb;
+ 	cfg.set_ie_cb = hostapd_wps_set_ie_cb;
+ 	cfg.pin_needed_cb = hostapd_wps_pin_needed_cb;
+@@ -1869,6 +2062,12 @@ static int wps_ap_pin_set(struct hostapd_data *hapd, void *ctx)
+ 	return 0;
+ }
+ 
++#if defined(CONFIG_DRIVER_BRCM) && defined(CONFIG_WPS_UPNP)
++int hostapd_wps_upnp_ifcae_ip_changed(struct hostapd_data *hapd)
++{
++	return upnp_wps_web_listener_sock_update(hapd->wps_upnp, hapd->conf->upnp_iface);
++}
++#endif	/* CONFIG_DRIVER_BRCM && CONFIG_WPS_UPNP */
+ 
+ const char * hostapd_wps_ap_pin_random(struct hostapd_data *hapd, int timeout)
+ {
+@@ -1973,6 +2172,56 @@ int hostapd_wps_config_ap(struct hostapd_data *hapd, const char *ssid,
+ 	return wps_registrar_config_ap(hapd->wps->registrar, &cred);
+ }
+ 
++#ifdef CONFIG_DRIVER_BRCM_MAP
++int hostapd_wps_config_map_bh(struct hostapd_data *hapd, const char *ssid,
++                const char *auth, const char *encr, const char *key)
++{
++        struct wps_credential cred;
++        size_t len;
++
++        os_memset(&cred, 0, sizeof(cred));
++
++        len = os_strlen(ssid);
++        if ((len <= 0) || len > sizeof(cred.ssid))
++                return -1;
++        cred.ssid_len = len;
++        os_memcpy(cred.ssid, ssid, len);
++
++        if (os_strncmp(auth, "OPEN", 4) == 0)
++                cred.auth_type = WPS_AUTH_OPEN;
++        else if (os_strncmp(auth, "WPAPSK", 6) == 0)
++                cred.auth_type = WPS_AUTH_WPAPSK;
++        else if (os_strncmp(auth, "WPA2PSK", 7) == 0)
++                cred.auth_type = WPS_AUTH_WPA2PSK;
++        else
++                return -1;
++
++        if (encr) {
++                if (os_strncmp(encr, "NONE", 4) == 0)
++                        cred.encr_type = WPS_ENCR_NONE;
++                else if (os_strncmp(encr, "TKIP", 4) == 0)
++                        cred.encr_type = WPS_ENCR_TKIP;
++                else if (os_strncmp(encr, "CCMP", 4) == 0)
++                        cred.encr_type = WPS_ENCR_AES;
++                else
++                        return -1;
++        } else
++                cred.encr_type = WPS_ENCR_NONE;
++
++        if (key) {
++                len = os_strlen(key);
++                if (len <= 8 && len > sizeof(cred.key)) {
++                        return -1;
++                }
++                cred.key_len = len;
++                os_memcpy(cred.key, key, len);
++        }
++
++        os_memcpy(&hapd->wps->bh_creds, &cred, sizeof(hapd->wps->bh_creds));
++        return 0;
++}
++#endif /* CONFIG_DRIVER_BRCM_MAP */
++
+ 
+ #ifdef CONFIG_WPS_NFC
+ 
+diff --git a/src/ap/wps_hostapd.h b/src/ap/wps_hostapd.h
+index 204bd820a..45dc4f432 100644
+--- a/src/ap/wps_hostapd.h
++++ b/src/ap/wps_hostapd.h
+@@ -30,8 +30,15 @@ const char * hostapd_wps_ap_pin_get(struct hostapd_data *hapd);
+ int hostapd_wps_ap_pin_set(struct hostapd_data *hapd, const char *pin,
+ 			   int timeout);
+ void hostapd_wps_update_ie(struct hostapd_data *hapd);
++#if defined(CONFIG_DRIVER_BRCM) && defined(CONFIG_WPS_UPNP)
++int hostapd_wps_upnp_ifcae_ip_changed(struct hostapd_data *hapd);
++#endif	/* CONFIG_DRIVER_BRCM && CONFIG_WPS_UPNP */
+ int hostapd_wps_config_ap(struct hostapd_data *hapd, const char *ssid,
+ 			  const char *auth, const char *encr, const char *key);
++#ifdef CONFIG_DRIVER_BRCM_MAP
++int hostapd_wps_config_map_bh(struct hostapd_data *hapd, const char *ssid,
++                          const char *auth, const char *encr, const char *key);
++#endif  /* CONFIG_DRIVER_BRCM_MAP */
+ int hostapd_wps_nfc_tag_read(struct hostapd_data *hapd,
+ 			     const struct wpabuf *data);
+ struct wpabuf * hostapd_wps_nfc_config_token(struct hostapd_data *hapd,
+diff --git a/src/common/hw_features_common.c b/src/common/hw_features_common.c
+index 732124f4d..fe6900764 100644
+--- a/src/common/hw_features_common.c
++++ b/src/common/hw_features_common.c
+@@ -417,12 +417,14 @@ int hostapd_set_freq_params(struct hostapd_freq_params *data,
+ 				 &data->edmg);
+ 
+ 	if (is_6ghz_freq(freq)) {
++#ifndef CONFIG_DRIVER_BRCM /* TODO :6GHZ: Enable with CONFIG_IEEE80211AX=y and \
++	ieee80211ax=1 */
+ 		if (!data->he_enabled && !data->eht_enabled) {
+ 			wpa_printf(MSG_ERROR,
+ 				   "Can't set 6 GHz mode - HE or EHT aren't enabled");
+ 			return -1;
+ 		}
+-
++#endif
+ 		if (center_idx_to_bw_6ghz(channel) < 0) {
+ 			wpa_printf(MSG_ERROR,
+ 				   "Invalid control channel for 6 GHz band");
+diff --git a/src/common/ieee802_11_common.c b/src/common/ieee802_11_common.c
+index 9e348a21c..86027e466 100644
+--- a/src/common/ieee802_11_common.c
++++ b/src/common/ieee802_11_common.c
+@@ -1179,7 +1179,7 @@ static const char *const eu_op_class_cc[] = {
+ 	"AL", "AM", "AT", "AZ", "BA", "BE", "BG", "BY", "CH", "CY", "CZ", "DE",
+ 	"DK", "EE", "EL", "ES", "FI", "FR", "GE", "HR", "HU", "IE", "IS", "IT",
+ 	"LI", "LT", "LU", "LV", "MD", "ME", "MK", "MT", "NL", "NO", "PL", "PT",
+-	"RO", "RS", "RU", "SE", "SI", "SK", "TR", "UA", "UK", NULL
++	"RO", "RS", "RU", "SE", "SI", "SK", "TR", "UA", "UK", "GB", NULL
+ };
+ 
+ static const char *const jp_op_class_cc[] = {
+@@ -1454,7 +1454,13 @@ static int ieee80211_chan_to_freq_global(u8 op_class, u8 chan)
+ 	case 135: /* UHB channels, 80+80 MHz: 7, 23, 39.. */
+ 		if (chan < 1 || chan > 233)
+ 			return -1;
+-		return 5950 + chan * 5;
++#ifndef CONFIG_DRIVER_BRCM
++		return 5940 + chan * 5;
++#else
++		/* New 6GHz channelization - May 2020 */
++		if (chan == 2) return 5935;
++		else return 5950 + chan * 5;
++#endif /* CONFIG_DRIVER_BRCM */
+ 	case 136: /* UHB channels, 20 MHz: 2 */
+ 		if (chan == 2)
+ 			return 5935;
+@@ -2272,7 +2278,11 @@ int center_idx_to_bw_6ghz(u8 idx)
+ 
+ bool is_6ghz_freq(int freq)
+ {
++#ifdef CONFIG_DRIVER_BRCM
++	if (freq < 5935 || freq > 7125)
++#else
+ 	if (freq < 5935 || freq > 7115)
++#endif
+ 		return false;
+ 
+ 	if (freq == 5935)
+@@ -2297,13 +2307,24 @@ bool is_6ghz_psc_frequency(int freq)
+ 
+ 	if (!is_6ghz_freq(freq) || freq == 5935)
+ 		return false;
++#ifndef CONFIG_DRIVER_BRCM
+ 	if ((((freq - 5950) / 5) & 0x3) != 0x1)
+ 		return false;
+ 
+ 	i = (freq - 5950 + 55) % 80;
+ 	if (i == 0)
+ 		i = (freq - 5950 + 55) / 80;
++#else
++	/* New 6GHz channelization - May 2020 */
++	if (freq == 5935)
++		return 0;
++	if ((((freq - 5950) / 5) & 0x3) != 0x1)
++		return 0;
+ 
++	i = (freq - 5950 + 55) % 80;
++	if (i == 0)
++		i = (freq - 5950 + 55) / 80;
++#endif /* CONFIG_DRIVER_BRCM */
+ 	if (i >= 1 && i <= 15)
+ 		return true;
+ 
+diff --git a/src/common/ieee802_11_defs.h b/src/common/ieee802_11_defs.h
+index ffa93f320..659b7199c 100644
+--- a/src/common/ieee802_11_defs.h
++++ b/src/common/ieee802_11_defs.h
+@@ -272,7 +272,7 @@
+ #define WLAN_REASON_MAC_ADDRESS_ALREADY_EXISTS_IN_MBSS 64
+ #define WLAN_REASON_MESH_CHANNEL_SWITCH_REGULATORY_REQ 65
+ #define WLAN_REASON_MESH_CHANNEL_SWITCH_UNSPECIFIED 66
+-
++#define WLAN_RADIUS_GREYLIST_REJECT 100
+ 
+ /* Information Element IDs (IEEE Std 802.11-2016, 9.4.2.1, Table 9-77) */
+ #define WLAN_EID_SSID 0
+@@ -2545,7 +2545,9 @@ enum edmg_bw_config {
+ };
+ 
+ /* DPP Public Action frame identifiers - OUI_WFA */
++#ifndef DPP_OUI_TYPE
+ #define DPP_OUI_TYPE 0x1A
++#endif
+ 
+ /* Robust AV streaming Action field values */
+ enum robust_av_streaming_action {
+diff --git a/src/common/wpa_common.c b/src/common/wpa_common.c
+index 27336c927..b9681d0fb 100644
+--- a/src/common/wpa_common.c
++++ b/src/common/wpa_common.c
+@@ -1452,6 +1452,10 @@ static int rsn_selector_to_bitfield(const u8 *s)
+ 		return WPA_CIPHER_BIP_CMAC_256;
+ 	if (RSN_SELECTOR_GET(s) == RSN_CIPHER_SUITE_NO_GROUP_ADDRESSED)
+ 		return WPA_CIPHER_GTK_NOT_USED;
++#ifdef CONFIG_DRIVER_BRCM
++        if (RSN_SELECTOR_GET(s) == BRCM_CIPHER_SUITE_NO_GROUP_ADDRESSED)
++                return WPA_CIPHER_CCMP;
++#endif /* CONFIG_DRIVER_BRCM */
+ 	return 0;
+ }
+ 
+diff --git a/src/common/wpa_common.h b/src/common/wpa_common.h
+index c28c55d3a..afbba11eb 100644
+--- a/src/common/wpa_common.h
++++ b/src/common/wpa_common.h
+@@ -110,6 +110,9 @@ WPA_CIPHER_BIP_CMAC_256)
+ #define RSN_CIPHER_SUITE_CMIC RSN_SELECTOR(0x00, 0x40, 0x96, 2)
+ /* KRK is defined for nl80211 use only */
+ #define RSN_CIPHER_SUITE_KRK RSN_SELECTOR(0x00, 0x40, 0x96, 255)
++#ifdef CONFIG_DRIVER_BRCM
++#define BRCM_CIPHER_SUITE_NO_GROUP_ADDRESSED RSN_SELECTOR(0x00, 0x10, 0x18, 0)
++#endif /* CONFIG_DRIVER_BRCM */
+ 
+ /* EAPOL-Key Key Data Encapsulation
+  * GroupKey and PeerKey require encryption, otherwise, encryption is optional.
+diff --git a/src/common/wpa_ctrl.c b/src/common/wpa_ctrl.c
+index 7e197f094..52927fa2e 100644
+--- a/src/common/wpa_ctrl.c
++++ b/src/common/wpa_ctrl.c
+@@ -774,3 +774,43 @@ int wpa_ctrl_get_fd(struct wpa_ctrl *ctrl)
+ #endif /* CONFIG_CTRL_IFACE_NAMED_PIPE */
+ 
+ #endif /* CONFIG_CTRL_IFACE */
++
++//CONFIG MACRO
++#ifndef CONFIG_CTRL_IFACE
++struct wpa_ctrl * wpa_ctrl_open(const char *ctrl_path)
++{
++    return NULL;
++}
++
++int wpa_ctrl_request(struct wpa_ctrl *ctrl, const char *cmd, size_t cmd_len,
++        char *reply, size_t *reply_len,
++        void (*msg_cb)(char *msg, size_t len))
++{
++    return 0;
++}
++
++void wpa_ctrl_close(struct wpa_ctrl *ctrl)
++{
++
++}
++
++static int wpa_ctrl_attach_helper(struct wpa_ctrl *ctrl, int attach)
++{
++    return 0;
++}
++
++int wpa_ctrl_get_fd(struct wpa_ctrl *ctrl)
++{
++    return 0;
++}
++
++int wpa_ctrl_recv(struct wpa_ctrl *ctrl, char *reply, size_t *reply_len)
++{
++    return 0;
++}
++
++int wpa_ctrl_attach(struct wpa_ctrl *ctrl)
++{
++    return 0;
++}
++#endif /* CONFIG_CTRL_IFACE */
+\ No newline at end of file
+diff --git a/src/crypto/crypto_openssl.c b/src/crypto/crypto_openssl.c
+index c6e065f82..a5bb1b296 100644
+--- a/src/crypto/crypto_openssl.c
++++ b/src/crypto/crypto_openssl.c
+@@ -1764,7 +1764,7 @@ int crypto_get_random(void *buf, size_t len)
+ 		return -1;
+ 	return 0;
+ }
+-
++#ifdef CONFIG_OPENSSL_CMAC
+ 
+ int omac1_aes_vector(const u8 *key, size_t key_len, size_t num_elem,
+ 		     const u8 *addr[], const size_t *len, u8 *mac)
+@@ -1864,7 +1864,7 @@ int omac1_aes_256(const u8 *key, const u8 *data, size_t data_len, u8 *mac)
+ {
+ 	return omac1_aes_vector(key, 32, 1, &data, &data_len, mac);
+ }
+-
++#endif
+ 
+ struct crypto_bignum * crypto_bignum_init(void)
+ {
+diff --git a/src/crypto/random.c b/src/crypto/random.c
+index 548b60dba..fa54d64b2 100644
+--- a/src/crypto/random.c
++++ b/src/crypto/random.c
+@@ -255,6 +255,14 @@ int random_pool_ready(void)
+ 	res = -1;
+ #endif /* CONFIG_GETRANDOM */
+ 	if (res < 0) {
++#ifdef true
++                fd = open("/dev/urandom", O_RDONLY | O_NONBLOCK);
++                if (fd < 0) {
++                        wpa_printf(MSG_ERROR, "random: Cannot open /dev/urandom: %s",
++                                        strerror(errno));
++                        return -1;
++                }
++#else
+ 		fd = open("/dev/random", O_RDONLY | O_NONBLOCK);
+ 		if (fd < 0) {
+ 			wpa_printf(MSG_ERROR,
+@@ -262,7 +270,7 @@ int random_pool_ready(void)
+ 				   strerror(errno));
+ 			return -1;
+ 		}
+-
++#endif /* CONFIG_DRIVER_BRCM */
+ 		res = read(fd, stub_key + stub_key_avail,
+ 			   sizeof(stub_key) - stub_key_avail);
+ 		if (res < 0) {
+@@ -338,6 +346,17 @@ static void random_read_fd(int sock, void *eloop_ctx, void *sock_ctx)
+ 
+ 	res = read(sock, stub_key + stub_key_avail,
+ 		   sizeof(stub_key) - stub_key_avail);
++#ifdef true
++        if (res < 0) {
++                wpa_printf(MSG_ERROR, "random: Cannot read from /dev/urandom: "
++                           "%s", strerror(errno));
++                return;
++        }
++
++        wpa_printf(MSG_DEBUG, "random: Got %u/%u bytes from /dev/urandom",
++                   (unsigned) res,
++                   (unsigned) (sizeof(stub_key) - stub_key_avail));
++#else
+ 	if (res < 0) {
+ 		wpa_printf(MSG_ERROR, "random: Cannot read from /dev/random: "
+ 			   "%s", strerror(errno));
+@@ -347,6 +366,7 @@ static void random_read_fd(int sock, void *eloop_ctx, void *sock_ctx)
+ 	wpa_printf(MSG_DEBUG, "random: Got %u/%u bytes from /dev/random",
+ 		   (unsigned) res,
+ 		   (unsigned) (sizeof(stub_key) - stub_key_avail));
++#endif /* CONFIG_DRIVER_BRCM */
+ 	stub_key_avail += res;
+ 
+ 	if (stub_key_avail == sizeof(stub_key)) {
+@@ -450,7 +470,16 @@ void random_init(const char *entropy_file)
+ 		}
+ 	}
+ #endif /* CONFIG_GETRANDOM */
+-
++#ifdef true
++        random_fd = open("/dev/urandom", O_RDONLY | O_NONBLOCK);
++        if (random_fd < 0) {
++                wpa_printf(MSG_ERROR, "random: Cannot open /dev/urandom: %s",
++                           strerror(errno));
++                return;
++        }
++        wpa_printf(MSG_DEBUG, "random: Trying to read entropy from "
++                   "/dev/urandom");
++#else
+ 	random_fd = open("/dev/random", O_RDONLY | O_NONBLOCK);
+ 	if (random_fd < 0) {
+ 		wpa_printf(MSG_ERROR, "random: Cannot open /dev/random: %s",
+@@ -459,6 +488,7 @@ void random_init(const char *entropy_file)
+ 	}
+ 	wpa_printf(MSG_DEBUG, "random: Trying to read entropy from "
+ 		   "/dev/random");
++#endif /* CONFIG_DRIVER_BRCM */
+ 
+ 	eloop_register_read_sock(random_fd, random_read_fd, NULL, NULL);
+ #endif /* __linux__ */
+diff --git a/src/crypto/tls_openssl.c b/src/crypto/tls_openssl.c
+index 6602ac64f..5fe7739c4 100644
+--- a/src/crypto/tls_openssl.c
++++ b/src/crypto/tls_openssl.c
+@@ -1146,6 +1146,10 @@ void * tls_init(const struct tls_config *conf)
+ 	}
+ #endif /* OPENSSL_NO_ENGINE */
+ 
++#ifndef TLS_DEFAULT_CIPHERS
++#define TLS_DEFAULT_CIPHERS "DEFAULT:!EXP:!LOW"
++#endif /* TLS_DEFAULT_CIPHERS */
++
+ 	if (conf && conf->openssl_ciphers)
+ 		ciphers = conf->openssl_ciphers;
+ 	else
+diff --git a/src/drivers/driver.h b/src/drivers/driver.h
+index 6c00fb564..e20013781 100644
+--- a/src/drivers/driver.h
++++ b/src/drivers/driver.h
+@@ -3230,6 +3230,8 @@ struct wpa_driver_ops {
+ 	int (*sta_deauth)(void *priv, const u8 *own_addr, const u8 *addr,
+ 			  u16 reason);
+ 
++	int (*sta_notify_deauth)(void *priv, const u8 *own_addr, const u8 *addr,
++			  u16 reason);
+ 	/**
+ 	 * sta_disassoc - Disassociate a station (AP only)
+ 	 * @priv: Private driver interface data
+@@ -3496,6 +3498,17 @@ struct wpa_driver_ops {
+ 			     const struct wpabuf *proberesp,
+ 			     const struct wpabuf *assocresp);
+ 
++#ifdef RDK_ONEWIFI
++	/**
++	 * wps_event_notify_cb - Notification of WPS event
++	 * @ctx:   wpa_supplicant context
++	 * @event: wps event type
++	 * @data:  wps event data
++	 * Returns: 0 on success, -1 on failure
++	 */
++	int (*wps_event_notify_cb)(void *ctx, unsigned int event, void *data);
++#endif //RDK_ONEWIFI
++
+ 	/**
+ 	 * set_supp_port - Set IEEE 802.1X Supplicant Port status
+ 	 * @priv: Private driver interface data
+@@ -4620,7 +4633,16 @@ struct wpa_driver_ops {
+ 	 */
+ 	int (*update_dh_ie)(void *priv, const u8 *peer_mac, u16 reason_code,
+ 			    const u8 *ie, size_t ie_len);
+-
++#ifdef CONFIG_DRIVER_BRCM
++	/**
++	 * stop_bss - stop beacon on BSS
++	 * @priv: Private driver interface data
++	 * Returns: 0 on success, -1 on failure (or if not supported)
++	 *
++	 * This optional function can be used to disable beaconing on BSS.
++	 */
++	int (*stop_bss)(void *priv);
++#endif /* CONFIG_DRIVER_BRCM */
+ 	/**
+ 	 * dpp_listen - Notify driver about start/stop of DPP listen
+ 	 * @priv: Private driver interface data
+@@ -4632,11 +4654,17 @@ struct wpa_driver_ops {
+ 	 */
+ 	int (*dpp_listen)(void *priv, bool enable);
+ 
++	size_t (*get_rnr_colocation_len)(void *priv,
++				       size_t *current_len);
++	u8* (*get_rnr_colocation_ie)(void *priv, u8 *eid,
++				   size_t *current_len);
++
+ #ifdef CONFIG_TESTING_OPTIONS
+ 	int (*register_frame)(void *priv, u16 type,
+ 			      const u8 *match, size_t match_len,
+ 			      bool multicast);
+ #endif /* CONFIG_TESTING_OPTIONS */
++	int (*radius_eap_failure)(void *priv, int failure_reason);
+ };
+ 
+ /**
+@@ -4817,6 +4845,11 @@ enum wpa_event_type {
+ 	 */
+ 	EVENT_WPS_BUTTON_PUSHED,
+ 
++	/**
++	 * EVENT_WPS_CANCEL - Terminate current WPS session
++	 */
++	EVENT_WPS_CANCEL,
++
+ 	/**
+ 	 * EVENT_TX_STATUS - Report TX status
+ 	 */
+@@ -5196,7 +5229,12 @@ enum wpa_event_type {
+ 	 * is required to provide more details of the frame.
+ 	 */
+ 	EVENT_UNPROT_BEACON,
+-
++#ifdef CONFIG_DRIVER_BRCM
++	/**
++	  * EVENT_INTERFACE_ADDR_CHANGED - Notification of updated ip addr for interface
++	  */
++	EVENT_INTERFACE_IP_ADDR_CHANGED,
++#endif	/* CONFIG_DRIVER_BRCM */
+ 	/**
+ 	 * EVENT_TX_WAIT_EXPIRE - TX wait timed out
+ 	 *
+diff --git a/src/drivers/driver_common.c b/src/drivers/driver_common.c
+index 8db786168..731869435 100644
+--- a/src/drivers/driver_common.c
++++ b/src/drivers/driver_common.c
+@@ -97,6 +97,15 @@ const char * event_to_string(enum wpa_event_type event)
+ 	E2S(CCA_NOTIFY);
+ 	}
+ 
++    /* We can't add this event in the previous block as a mxl puma7 patch
++     * conflicts with this.
++     * Need to add a second junk block for the new events to avoid possible
++     * conflicts with hostapd 2.10 under cmxb7 build.
++     */
++    switch(event) {
++    E2S(WPS_CANCEL);
++    }
++
+ 	return "UNKNOWN";
+ #undef E2S
+ }
+diff --git a/src/drivers/driver_nl80211.c b/src/drivers/driver_nl80211.c
+index fa89a006b..8659beb7b 100644
+--- a/src/drivers/driver_nl80211.c
++++ b/src/drivers/driver_nl80211.c
+@@ -1253,6 +1253,18 @@ static void wpa_driver_nl80211_event_rtm_newlink(void *ctx,
+ 			wpa_printf(MSG_DEBUG,
+ 				   "nl80211: Not the main interface (%s) - do not indicate interface down",
+ 				   drv->first_bss->ifname);
++#ifdef CONFIG_DRIVER_BRCM
++		struct i802_bss *bss = get_bss_ifindex(drv, ifi->ifi_index);
++		if (bss == NULL) {
++			wpa_printf(MSG_INFO, "nl80211: BSS not avaliable");
++			return;
++		}
++
++		wpa_printf(MSG_INFO, "nl80211: stop beacon on %s", ifname);
++		struct hostapd_data *hapd = (struct hostapd_data *)bss->ctx;
++		hostapd_stop_beacon_on_vif(hapd);
++		bss->beacon_set = 0;
++#endif /* CONFIG_DRIVER_BRCM */
+ 		} else if (drv->ignore_if_down_event) {
+ 			wpa_printf(MSG_DEBUG, "nl80211: Ignore interface down "
+ 				   "event generated by mode change");
+@@ -1273,7 +1285,28 @@ static void wpa_driver_nl80211_event_rtm_newlink(void *ctx,
+ 				return;
+ 		}
+ 	}
++#ifdef CONFIG_DRIVER_BRCM
++	if ((ifi->ifi_flags & IFF_UP)
++			&& (os_strcmp(drv->first_bss->ifname, ifname) != 0)) {
++
++		struct i802_bss *bss = get_bss_ifindex(drv, ifi->ifi_index);
++		if (bss == NULL) {
++			wpa_printf(MSG_INFO, "nl80211: BSS not avaliable");
++			goto event_newlink;
++		}
++
++		if (bss->beacon_set == 0) {
++			wpa_printf(MSG_INFO, "nl80211: set beacon on %s", ifname);
++			struct hostapd_data *hapd = (struct hostapd_data *)bss->ctx;
++			hostapd_set_beacon_on_vif(hapd);
++			bss->beacon_set = 1;
++		} else {
++			wpa_printf(MSG_DEBUG, "nl80211: beacon already set on %s", ifname);
++		}
+ 
++		goto event_newlink;
++	}
++#endif /* CONFIG_DRIVER_BRCM */
+ 	if (drv->if_disabled && (ifi->ifi_flags & IFF_UP)) {
+ 		namebuf[0] = '\0';
+ 		if (if_indextoname(ifi->ifi_index, namebuf) &&
+@@ -1425,6 +1458,45 @@ static void wpa_driver_nl80211_event_rtm_dellink(void *ctx,
+ 						 ifname);
+ }
+ 
++#ifdef CONFIG_DRIVER_BRCM
++static void wpa_driver_nl80211_event_rtm_newaddr(void *ctx,
++						 struct ifaddrmsg *ifa,
++						 u8 *buf, size_t len)
++{
++	struct nl80211_global *global = ctx;
++	struct wpa_driver_nl80211_data *drv;
++	int attrlen;
++	struct rtattr *attr;
++	char ifname[IFNAMSIZ + 1];
++	char ip_addr[INET_ADDRSTRLEN];
++	union wpa_event_data event;
++
++	attrlen = len;
++	attr = (struct rtattr *) buf;
++	while (RTA_OK(attr, attrlen)) {
++		switch (attr->rta_type) {
++		case IFA_LOCAL:
++			if_indextoname(ifa->ifa_index, ifname);
++			inet_ntop(AF_INET, RTA_DATA(attr), ip_addr, sizeof(ip_addr));
++			wpa_printf(MSG_DEBUG, "nl80211: Ip address change is detected in "
++				"interface %s new ip %s ", ifname, ip_addr);
++			break;
++		}
++		attr = RTA_NEXT(attr, attrlen);
++	}
++
++	drv = nl80211_find_drv(global, ifa->ifa_index, buf, len, NULL);
++	if (drv) {
++		os_memset(&event, 0, sizeof(event));
++		event.interface_status.ifindex = ifa->ifa_index;
++		os_strlcpy(event.interface_status.ifname, ifname,
++				sizeof(event.interface_status.ifname));
++		wpa_printf(MSG_DEBUG, "nl80211: Ip address change detected for "
++				"interface %s raise EVENT_INTERFACE_IP_ADDR_CHANGED", ifname);
++		wpa_supplicant_event(drv->ctx, EVENT_INTERFACE_IP_ADDR_CHANGED, &event);
++	}
++}
++#endif /* CONFIG_DRIVER_BRCM */
+ 
+ struct nl80211_get_assoc_freq_arg {
+ 	struct wpa_driver_nl80211_data *drv;
+@@ -2675,6 +2747,20 @@ out_err:
+ 
+ static int nl80211_mgmt_subscribe_ap_dev_sme(struct i802_bss *bss)
+ {
++#ifdef CONFIG_DRIVER_BRCM
++        static const int stypes[] = {
++                WLAN_FC_STYPE_AUTH,
++                WLAN_FC_STYPE_ASSOC_REQ,
++                WLAN_FC_STYPE_REASSOC_REQ,
++                /* Beacon doesn't work as mac80211 doesn't currently allow
++                 * it, but it wouldn't really be the right thing anyway as
++                 * it isn't per interface ... maybe just dump the scan
++                 * results periodically for OLBC?
++                 */
++                /* WLAN_FC_STYPE_BEACON, */
++        };
++        unsigned int i;
++#endif /* CONFIG_DRIVER_BRCM */
+ 	if (nl80211_alloc_mgmt_handle(bss))
+ 		return -1;
+ 	wpa_printf(MSG_DEBUG, "nl80211: Subscribe to mgmt frames with AP "
+@@ -2684,6 +2770,16 @@ static int nl80211_mgmt_subscribe_ap_dev_sme(struct i802_bss *bss)
+ 		goto out_err;
+ 
+ 	if (bss->drv->device_ap_sme) {
++#ifdef CONFIG_DRIVER_BRCM
++        for (i = 0; i < ARRAY_SIZE(stypes); i++) {
++                if (nl80211_register_frame(bss, bss->nl_mgmt,
++                                           (WLAN_FC_TYPE_MGMT << 2) |
++                                           (stypes[i] << 4),
++                                           NULL, 0, false) < 0) {
++                        goto out_err;
++                }
++        }
++#else
+ 		u16 type = (WLAN_FC_TYPE_MGMT << 2) | (WLAN_FC_STYPE_AUTH << 4);
+ 
+ 		/* Register for all Authentication frames */
+@@ -2691,6 +2787,7 @@ static int nl80211_mgmt_subscribe_ap_dev_sme(struct i802_bss *bss)
+ 					   false) < 0)
+ 			wpa_printf(MSG_DEBUG,
+ 				   "nl80211: Failed to subscribe to handle Authentication frames - SAE offload may not work");
++#endif /* CONFIG_DRIVER_BRCM */
+ 	}
+ 
+ 	nl80211_mgmt_handle_register_eloop(bss);
+@@ -2943,6 +3040,19 @@ static int wpa_driver_nl80211_del_beacon(struct i802_bss *bss)
+ 	return send_and_recv_msgs(drv, msg, NULL, NULL, NULL, NULL);
+ }
+ 
++#ifdef CONFIG_DRIVER_BRCM
++static int wpa_driver_nl80211_del_beacon_bss(struct i802_bss *bss)
++{
++	struct nl_msg *msg;
++	struct wpa_driver_nl80211_data *drv = bss->drv;
++
++	wpa_printf(MSG_INFO, "nl80211: Remove beacon (ifindex=%d, bss=%s)",
++			drv->ifindex, bss->ifname);
++	msg = nl80211_bss_msg(bss, 0, NL80211_CMD_DEL_BEACON);
++	nl80211_put_wiphy_data_ap(bss);
++	return send_and_recv_msgs(drv, msg, NULL, NULL, NULL, NULL);
++}
++#endif /* CONFIG_DRIVER_BRCM */
+ 
+ /**
+  * wpa_driver_nl80211_deinit - Deinitialize nl80211 driver interface
+@@ -5475,7 +5585,10 @@ static int nl80211_create_iface_once(struct wpa_driver_nl80211_data *drv,
+ 	msg = nl80211_cmd_msg(drv->first_bss, 0, NL80211_CMD_NEW_INTERFACE);
+ 	if (!msg ||
+ 	    nla_put_string(msg, NL80211_ATTR_IFNAME, ifname) ||
+-	    nla_put_u32(msg, NL80211_ATTR_IFTYPE, iftype))
++#ifdef CONFIG_DRIVER_BRCM
++        nla_put(msg, NL80211_ATTR_MAC, ETH_ALEN, addr) ||
++#endif /* CONFIG_DRIVER_BRCM */
++		nla_put_u32(msg, NL80211_ATTR_IFTYPE, iftype))
+ 		goto fail;
+ 
+ 	if (iftype == NL80211_IFTYPE_MONITOR) {
+@@ -5492,13 +5605,15 @@ static int nl80211_create_iface_once(struct wpa_driver_nl80211_data *drv,
+ 			goto fail;
+ 	}
+ 
++/* CMWIFI_RDKB_COMCAST */
++#ifndef CONFIG_DRIVER_BRCM
+ 	/*
+ 	 * Tell cfg80211 that the interface belongs to the socket that created
+ 	 * it, and the interface should be deleted when the socket is closed.
+ 	 */
+ 	if (nla_put_flag(msg, NL80211_ATTR_IFACE_SOCKET_OWNER))
+ 		goto fail;
+-
++#endif /* CONFIG_DRIVER_BRCM */
+ 	if ((addr && iftype == NL80211_IFTYPE_P2P_DEVICE) &&
+ 	    nla_put(msg, NL80211_ATTR_MAC, ETH_ALEN, addr))
+ 		goto fail;
+@@ -8736,6 +8851,9 @@ static void * nl80211_global_init(void *ctx)
+ 	cfg->ctx = global;
+ 	cfg->newlink_cb = wpa_driver_nl80211_event_rtm_newlink;
+ 	cfg->dellink_cb = wpa_driver_nl80211_event_rtm_dellink;
++#ifdef CONFIG_DRIVER_BRCM
++	cfg->newaddr_cb = wpa_driver_nl80211_event_rtm_newaddr;
++#endif	/* CONFIG_DRIVER_BRCM */
+ 	global->netlink = netlink_init(cfg);
+ 	if (global->netlink == NULL) {
+ 		os_free(cfg);
+@@ -12192,6 +12310,23 @@ fail:
+ 	return ret;
+ }
+ 
++#ifdef CONFIG_DRIVER_BRCM
++static int wpa_driver_nl80211_stop_bss(void *priv)
++{
++	struct i802_bss *bss = priv;
++	struct wpa_driver_nl80211_data *drv = bss->drv;
++	struct hostapd_data *hapd = (struct hostapd_data *)bss->ctx;
++
++	if (!is_ap_interface(drv->nlmode)) {
++		return -1;
++	}
++
++	wpa_driver_nl80211_del_beacon_bss(bss);
++	bss->beacon_set = 0;
++
++	return 0;
++}
++#endif /* CONFIG_DRIVER_BRCM */
+ 
+ #ifdef CONFIG_DPP
+ static int nl80211_dpp_listen(void *priv, bool enable)
+@@ -12281,6 +12416,11 @@ const struct wpa_driver_ops wpa_driver_nl80211_ops = {
+ 	.get_capa = wpa_driver_nl80211_get_capa,
+ 	.set_operstate = wpa_driver_nl80211_set_operstate,
+ 	.set_supp_port = wpa_driver_nl80211_set_supp_port,
++#ifdef CONFIG_DRIVER_BRCM
++    .set_country = NULL,
++#else
++	.set_country = wpa_driver_nl80211_set_country,
++#endif /* CONFIG_DRIVER_BRCM  */
+ 	.set_country = wpa_driver_nl80211_set_country,
+ 	.get_country = wpa_driver_nl80211_get_country,
+ 	.set_ap = wpa_driver_nl80211_set_ap,
+@@ -12398,6 +12538,9 @@ const struct wpa_driver_ops wpa_driver_nl80211_ops = {
+ 	.update_connect_params = nl80211_update_connection_params,
+ 	.send_external_auth_status = nl80211_send_external_auth_status,
+ 	.set_4addr_mode = nl80211_set_4addr_mode,
++#ifdef CONFIG_DRIVER_BRCM
++	.stop_bss = wpa_driver_nl80211_stop_bss,
++#endif /* CONFIG_DRIVER_BRCM */
+ #ifdef CONFIG_DPP
+ 	.dpp_listen = nl80211_dpp_listen,
+ #endif /* CONFIG_DPP */
+diff --git a/src/drivers/driver_nl80211.h b/src/drivers/driver_nl80211.h
+index 80d456472..3df12b0c5 100644
+--- a/src/drivers/driver_nl80211.h
++++ b/src/drivers/driver_nl80211.h
+@@ -332,5 +332,9 @@ int wpa_driver_nl80211_abort_scan(void *priv, u64 scan_cookie);
+ int wpa_driver_nl80211_vendor_scan(struct i802_bss *bss,
+ 				   struct wpa_driver_scan_params *params);
+ int nl80211_set_default_scan_ies(void *priv, const u8 *ies, size_t ies_len);
++#ifdef CONFIG_DRIVER_BRCM
++void hostapd_set_beacon_on_vif(struct hostapd_data *hapd);
++void hostapd_stop_beacon_on_vif(struct hostapd_data *hapd);
++#endif /* CONFIG_DRIVER_BRCM */
+ 
+ #endif /* DRIVER_NL80211_H */
+diff --git a/src/drivers/driver_nl80211_event.c b/src/drivers/driver_nl80211_event.c
+index 22fb4f1e4..6053e9e8e 100644
+--- a/src/drivers/driver_nl80211_event.c
++++ b/src/drivers/driver_nl80211_event.c
+@@ -192,6 +192,10 @@ static void mlme_event_auth(struct wpa_driver_nl80211_data *drv,
+ {
+ 	const struct ieee80211_mgmt *mgmt;
+ 	union wpa_event_data event;
++#ifdef CONFIG_DRIVER_BRCM
++        u16 auth_type;
++        u16 fc, stype;
++#endif /* CONFIG_DRIVER_BRCM */
+ 
+ 	if (!(drv->capa.flags & WPA_DRIVER_FLAGS_SME) &&
+ 	    drv->force_connect_cmd) {
+@@ -215,17 +219,32 @@ static void mlme_event_auth(struct wpa_driver_nl80211_data *drv,
+ 	os_memcpy(drv->auth_bssid, mgmt->sa, ETH_ALEN);
+ 	os_memset(drv->auth_attempt_bssid, 0, ETH_ALEN);
+ 	os_memset(&event, 0, sizeof(event));
+-	os_memcpy(event.auth.peer, mgmt->sa, ETH_ALEN);
+-	event.auth.auth_type = le_to_host16(mgmt->u.auth.auth_alg);
+-	event.auth.auth_transaction =
+-		le_to_host16(mgmt->u.auth.auth_transaction);
+-	event.auth.status_code = le_to_host16(mgmt->u.auth.status_code);
+-	if (len > 24 + sizeof(mgmt->u.auth)) {
+-		event.auth.ies = mgmt->u.auth.variable;
+-		event.auth.ies_len = len - 24 - sizeof(mgmt->u.auth);
++#ifdef CONFIG_DRIVER_BRCM
++        auth_type = le_to_host16(mgmt->u.auth.auth_alg);
++        fc = le_to_host16(mgmt->frame_control);
++        stype = WLAN_FC_GET_STYPE(fc);
++
++        if ((stype == WLAN_FC_STYPE_AUTH) &&
++                        (auth_type == WLAN_AUTH_SAE)) {
++                wpa_printf(MSG_DEBUG, "nl80211: SAE Authenticate event");
++                event.rx_mgmt.frame = frame;
++                event.rx_mgmt.frame_len = len;
++                wpa_supplicant_event(drv->ctx, EVENT_RX_MGMT, &event);
++        } else
++#endif /* CONFIG_DRIVER_BRCM */
++    {
++        os_memcpy(event.auth.peer, mgmt->sa, ETH_ALEN);
++        event.auth.auth_type = le_to_host16(mgmt->u.auth.auth_alg);
++        event.auth.auth_transaction =
++        le_to_host16(mgmt->u.auth.auth_transaction);
++        event.auth.status_code = le_to_host16(mgmt->u.auth.status_code);
++        if (len > 24 + sizeof(mgmt->u.auth)) {
++                event.auth.ies = mgmt->u.auth.variable;
++        event.auth.ies_len = len - 24 - sizeof(mgmt->u.auth);
++        }
++
++        wpa_supplicant_event(drv->ctx, EVENT_AUTH, &event);
+ 	}
+-
+-	wpa_supplicant_event(drv->ctx, EVENT_AUTH, &event);
+ }
+ 
+ 
+@@ -1542,6 +1561,14 @@ static void nl80211_new_station_event(struct wpa_driver_nl80211_data *drv,
+ {
+ 	u8 *addr;
+ 	union wpa_event_data data;
++#ifdef CONFIG_DRIVER_BRCM
++                struct nl80211_sta_flag_update *sta_flags;
++                static struct nla_policy stats_policy[NL80211_STA_INFO_MAX + 1] = {
++                        [NL80211_STA_INFO_STA_FLAGS] =
++                                { .minlen = sizeof(struct nl80211_sta_flag_update) },
++                };
++                struct nlattr *sinfo[NL80211_STA_INFO_MAX + 1];
++#endif // endif
+ 
+ 	if (tb[NL80211_ATTR_MAC] == NULL)
+ 		return;
+@@ -1551,10 +1578,42 @@ static void nl80211_new_station_event(struct wpa_driver_nl80211_data *drv,
+ 	if (is_ap_interface(drv->nlmode) && drv->device_ap_sme) {
+ 		u8 *ies = NULL;
+ 		size_t ies_len = 0;
++#ifdef CONFIG_DRIVER_BRCM
++		struct nl80211_sta_flag_update *sta_flags;
++		static struct nla_policy stats_policy[NL80211_STA_INFO_MAX + 1] = {
++			[NL80211_STA_INFO_STA_FLAGS] =
++				{ .minlen = sizeof(struct nl80211_sta_flag_update) },
++		};
++		struct nlattr *sinfo[NL80211_STA_INFO_MAX + 1];
++#endif /* CONFIG_DRIVER_BRCM */
+ 		if (tb[NL80211_ATTR_IE]) {
+ 			ies = nla_data(tb[NL80211_ATTR_IE]);
+ 			ies_len = nla_len(tb[NL80211_ATTR_IE]);
+ 		}
++#ifdef CONFIG_DRIVER_BRCM
++                if (tb[NL80211_ATTR_STA_INFO]) {
++                        if (nla_parse_nested(sinfo, NL80211_STA_INFO_MAX,
++                                tb[NL80211_ATTR_STA_INFO], stats_policy)) {
++                                wpa_printf(MSG_DEBUG, "nl80211: Failed to parse Station info attribute ");
++                                return ;
++                        }
++                        if (sinfo[NL80211_STA_INFO_STA_FLAGS]) {
++                                sta_flags = (struct nl80211_sta_flag_update *)
++                                            nla_data(sinfo[NL80211_STA_INFO_STA_FLAGS]);
++
++                                wpa_printf(MSG_DEBUG, "nl80211: sinfo sta_flags mask %d set %d ",
++                                                        sta_flags->mask, sta_flags->set);
++                                if ((sta_flags->mask & BIT(NL80211_STA_FLAG_ASSOCIATED)) &&
++                                    (sta_flags->mask & BIT(NL80211_STA_FLAG_AUTHENTICATED))) {
++                                        if ((sta_flags->set & BIT(NL80211_STA_FLAG_ASSOCIATED)) &&
++                                           (sta_flags->set & BIT(NL80211_STA_FLAG_AUTHENTICATED))) {
++                                                drv_event_assoc(bss->ctx, addr, ies, ies_len, 1);
++                                                return;
++                                        }
++                                }
++                        }
++                }
++#endif // endif
+ 		wpa_hexdump(MSG_DEBUG, "nl80211: Assoc Req IEs", ies, ies_len);
+ 		drv_event_assoc(bss->ctx, addr, ies, ies_len, 0);
+ 		return;
+diff --git a/src/drivers/linux_ioctl.c b/src/drivers/linux_ioctl.c
+index 7edb9df2e..eba6b81b2 100644
+--- a/src/drivers/linux_ioctl.c
++++ b/src/drivers/linux_ioctl.c
+@@ -15,6 +15,86 @@
+ #include "common/linux_bridge.h"
+ #include "linux_ioctl.h"
+ 
++#ifdef CONFIG_DRIVER_BRCM
++#include <sys/wait.h>
++#define OVS_MODULE "/sys/module/openvswitch"
++
++#define run_prog(p, ...) ({ \
++	int rc = -1, status; \
++	pid_t pid = fork(); \
++	if (!pid) \
++		exit(execlp(p, p, ##__VA_ARGS__, NULL)); \
++	if (pid < 0) {\
++		rc = -1;\
++	} else {\
++		while ((rc = waitpid(pid, &status, 0)) == -1 && errno == EINTR); \
++		rc = (rc == pid && WIFEXITED(status)) ? WEXITSTATUS(status) : -1; \
++	}\
++	rc;\
++})
++
++static
++int ovs_br_exists(const char *brname)
++{
++	char buf[128] = {};
++	char *p;
++	FILE *f;
++
++	f = popen("/usr/bin/ovs-vsctl list-br", "r");
++	while (f && (p = fgets(buf, sizeof(buf), f)))
++		if (!strcmp(strsep(&p, "\n") ?: "", brname))
++			break;
++
++	if (f) pclose(f);
++	return strlen(buf) > 0;
++}
++
++static
++int ovs_br_add_if(const char *brname, const char *ifname)
++{
++	printf("ovs-vsctl add-port %s %s\r\n", brname, ifname);
++	if (run_prog("/usr/bin/ovs-vsctl", "add-port", brname, ifname))
++		return -1;
++	return 0;
++}
++
++static
++int ovs_br_del_if(const char *brname, const char *ifname)
++{
++	printf("ovs-vsctl del-port %s %s\r\n", brname, ifname);
++
++	if (run_prog("/usr/bin/ovs-vsctl", "del-port", brname, ifname))
++		return -1;
++	return 0;
++}
++
++static
++int ovs_if_get_br(char *brname, const char *ifname)
++{
++	char cmd[128];
++	char *p;
++	FILE *f;
++
++	os_snprintf(cmd, sizeof(cmd), "/usr/bin/ovs-vsctl port-to-br %s", ifname);
++	f = popen(cmd, "r");
++	if (!f) return -1;
++	p = fgets(brname, IFNAMSIZ, f);
++	pclose(f);
++	if (p == NULL || strlen(p) == 0) return -1;
++	strsep(&p, "\n"); /* chomp \n */
++	return 0;
++}
++
++static
++int ovs_add_br(const char *brname)
++{
++	printf("ovs-vsctl add-br %s \r\n", brname);
++	if (run_prog("/usr/bin/ovs-vsctl", "add-br", brname)) {
++		return -1;
++	}
++	return 0;
++}
++#endif /* CONFIG_DRIVER_BRCM */
+ 
+ int linux_set_iface_flags(int sock, const char *ifname, int dev_up)
+ {
+@@ -122,6 +202,21 @@ int linux_set_ifhwaddr(int sock, const char *ifname, const u8 *addr)
+ 
+ int linux_br_add(int sock, const char *brname)
+ {
++#ifdef CONFIG_DRIVER_BRCM
++	if (access(OVS_MODULE, F_OK) == 0) {
++		wpa_printf(MSG_DEBUG, "Skipping creation of linux bridge in OpenvSwitch mode  %s",
++				   brname);
++		if ((strcmp(brname, "brlan2") != 0) ||
++			(strcmp(brname, "brlan3") != 0) ||
++			(strcmp(brname, "brlan4") != 0) ||
++			(strcmp(brname, "brlan5") != 0)) {
++			if ( ovs_add_br(brname) < 0) {
++				return -1;
++			}
++			return 0;
++		}
++	}
++#endif
+ 	if (ioctl(sock, SIOCBRADDBR, brname) < 0) {
+ 		int saved_errno = errno;
+ 
+@@ -152,6 +247,16 @@ int linux_br_add_if(int sock, const char *brname, const char *ifname)
+ 	struct ifreq ifr;
+ 	int ifindex;
+ 
++#ifdef CONFIG_DRIVER_BRCM
++	if (ovs_br_exists(brname)) {
++		if ((strcmp(brname, "brlan2") != 0) ||
++			(strcmp(brname, "brlan3") != 0) ||
++			(strcmp(brname, "brlan4") != 0) ||
++			(strcmp(brname, "brlan5") != 0)) {
++			return ovs_br_add_if(brname, ifname);
++		}
++	}
++#endif /* CONFIG_DRIVER_BRCM */
+ 	ifindex = if_nametoindex(ifname);
+ 	if (ifindex == 0)
+ 		return -1;
+@@ -177,6 +282,16 @@ int linux_br_del_if(int sock, const char *brname, const char *ifname)
+ 	struct ifreq ifr;
+ 	int ifindex;
+ 
++#ifdef CONFIG_DRIVER_BRCM
++	if (ovs_br_exists(brname)) {
++		if ((strcmp(brname, "brlan2") != 0) ||
++			(strcmp(brname, "brlan3") != 0) ||
++			(strcmp(brname, "brlan4") != 0) ||
++			(strcmp(brname, "brlan5") != 0)) {
++			return ovs_br_del_if(brname, ifname);
++		}
++	}
++#endif /* CONFIG_DRIVER_BRCM */
+ 	ifindex = if_nametoindex(ifname);
+ 	if (ifindex == 0)
+ 		return -1;
+@@ -203,7 +318,11 @@ int linux_br_get(char *brname, const char *ifname)
+ 		    ifname);
+ 	res = readlink(path, brlink, sizeof(brlink));
+ 	if (res < 0 || (size_t) res >= sizeof(brlink))
++#ifdef CONFIG_DRIVER_BRCM
++		return ovs_if_get_br(brname, ifname);
++#else
+ 		return -1;
++#endif /* CONFIG_DRIVER_BRCM */
+ 	brlink[res] = '\0';
+ 	pos = os_strrchr(brlink, '/');
+ 	if (pos == NULL)
+diff --git a/src/drivers/netlink.c b/src/drivers/netlink.c
+index 0e960f48c..faaeb0c56 100644
+--- a/src/drivers/netlink.c
++++ b/src/drivers/netlink.c
+@@ -32,6 +32,19 @@ static void netlink_receive_link(struct netlink_data *netlink,
+ 	   NLMSG_PAYLOAD(h, sizeof(struct ifinfomsg)));
+ }
+ 
++#ifdef CONFIG_DRIVER_BRCM
++static void netlink_receive_addr(struct netlink_data *netlink,
++				 void (*cb)(void *ctx, struct ifaddrmsg *ifa,
++					    u8 *buf, size_t len),
++				 struct nlmsghdr *h)
++{
++	if (cb == NULL || NLMSG_PAYLOAD(h, 0) < sizeof(struct ifaddrmsg))
++		return;
++	cb(netlink->cfg->ctx, NLMSG_DATA(h),
++	   (u8 *) NLMSG_DATA(h) + NLMSG_ALIGN(sizeof(struct ifaddrmsg)),
++	   NLMSG_PAYLOAD(h, sizeof(struct ifaddrmsg)));
++}
++#endif /* CONFIG_DRIVER_BRCM */
+ 
+ static void netlink_receive(int sock, void *eloop_ctx, void *sock_ctx)
+ {
+@@ -65,6 +78,12 @@ try_again:
+ 			netlink_receive_link(netlink, netlink->cfg->dellink_cb,
+ 					     h);
+ 			break;
++#ifdef CONFIG_DRIVER_BRCM
++		case RTM_NEWADDR:
++			netlink_receive_addr(netlink, netlink->cfg->newaddr_cb,
++					     h);
++			break;
++#endif	/* CONFIG_DRIVER_BRCM */
+ 		}
+ 
+ 		h = NLMSG_NEXT(h, left);
+@@ -107,7 +126,11 @@ struct netlink_data * netlink_init(struct netlink_config *cfg)
+ 
+ 	os_memset(&local, 0, sizeof(local));
+ 	local.nl_family = AF_NETLINK;
++#ifdef CONFIG_DRIVER_BRCM
++        local.nl_groups = RTMGRP_LINK | RTMGRP_IPV4_IFADDR;
++#else
+ 	local.nl_groups = RTMGRP_LINK;
++#endif /* CONFIG_DRIVER_BRCM */
+ 	if (bind(netlink->sock, (struct sockaddr *) &local, sizeof(local)) < 0)
+ 	{
+ 		wpa_printf(MSG_ERROR, "netlink: Failed to bind netlink "
+diff --git a/src/drivers/netlink.h b/src/drivers/netlink.h
+index 3a7340e51..8d4bc2a10 100644
+--- a/src/drivers/netlink.h
++++ b/src/drivers/netlink.h
+@@ -18,6 +18,10 @@ struct netlink_config {
+ 			   size_t len);
+ 	void (*dellink_cb)(void *ctx, struct ifinfomsg *ifi, u8 *buf,
+ 			   size_t len);
++#ifdef CONFIG_DRIVER_BRCM
++	void (*newaddr_cb)(void *ctx, struct ifaddrmsg *ifa, u8 *buf,
++			   size_t len);
++#endif	/* CONFIG_DRIVER_BRCM */
+ };
+ 
+ struct netlink_data * netlink_init(struct netlink_config *cfg);
+diff --git a/src/drivers/priv_netlink.h b/src/drivers/priv_netlink.h
+index d3f091c39..d0bc4a244 100644
+--- a/src/drivers/priv_netlink.h
++++ b/src/drivers/priv_netlink.h
+@@ -106,4 +106,22 @@ struct rtattr
+ 	unsigned short rta_type;
+ };
+ 
++#ifdef CONFIG_DRIVER_BRCM
++
++#ifndef IFA_LOCAL
++#define IFA_LOCAL 2
++#endif // endif
++#define RTMGRP_IPV4_IFADDR      0x10
++#define RTM_NEWADDR (RTM_BASE + 4)
++
++struct ifaddrmsg
++{
++        u8 ifa_family;
++        u8 ifa_prefixlen;       /* The prefix length    */
++        u8 ifa_flags;           /* Flag                 */
++        u8 ifa_scope;           /* Address scope        */
++        u32 ifa_index;          /* Link index           */
++};
++#endif  /* CONFIG_DRIVER_BRCM */
++
+ #endif /* PRIV_NETLINK_H */
+diff --git a/src/eapol_auth/eapol_auth_sm.c b/src/eapol_auth/eapol_auth_sm.c
+index 1c11cb613..5d14c42e3 100644
+--- a/src/eapol_auth/eapol_auth_sm.c
++++ b/src/eapol_auth/eapol_auth_sm.c
+@@ -940,6 +940,17 @@ restart:
+ 	}
+ 
+ 	if (eapol_sm_sta_entry_alive(eapol, addr) && sm->eap) {
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++		if ((sm->flags & EAPOL_SM_SKIP_EAP)) {
++			if (sm->eap_if->aaaEapResp) {
++				sm->eap_if->aaaEapResp = false;
++				sm->eapol->cb.aaa_send(
++					sm->eapol->conf.ctx, sm->sta,
++					NULL, 0);
++			}
++			return;
++		}
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 		if (eap_server_sm_step(sm->eap)) {
+ 			if (--max_steps > 0)
+ 				goto restart;
+diff --git a/src/eapol_auth/eapol_auth_sm.h b/src/eapol_auth/eapol_auth_sm.h
+index 61b7039d6..9bce52a3c 100644
+--- a/src/eapol_auth/eapol_auth_sm.h
++++ b/src/eapol_auth/eapol_auth_sm.h
+@@ -13,6 +13,9 @@
+ #define EAPOL_SM_WAIT_START BIT(1)
+ #define EAPOL_SM_USES_WPA BIT(2)
+ #define EAPOL_SM_FROM_PMKSA_CACHE BIT(3)
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++#define EAPOL_SM_SKIP_EAP BIT(4)
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 
+ struct eapol_auth_config {
+ 	const struct eap_config *eap_cfg;
+diff --git a/src/radius/radius.c b/src/radius/radius.c
+index a64228067..3f99a8529 100644
+--- a/src/radius/radius.c
++++ b/src/radius/radius.c
+@@ -1041,7 +1041,10 @@ int radius_msg_make_authenticator(struct radius_msg *msg)
+  * The returned payload is allocated with os_malloc() and caller must free it
+  * by calling os_free().
+  */
+-static u8 *radius_msg_get_vendor_attr(struct radius_msg *msg, u32 vendor,
++#ifndef FEATURE_SUPPORT_RADIUSGREYLIST
++static
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
++u8 *radius_msg_get_vendor_attr(struct radius_msg *msg, u32 vendor,
+ 				      u8 subtype, size_t *alen)
+ {
+ 	u8 *data, *pos;
+@@ -1871,3 +1874,31 @@ int radius_gen_session_id(u8 *id, size_t len)
+ 	 */
+ 	return os_get_random(id, len);
+ }
++
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++int radius_msg_add_comcast(struct radius_msg *msg, u8 subtype, const u8 *data,
++		       size_t len)
++{
++	struct radius_attr_hdr *attr;
++	u8 *buf, *pos;
++	size_t alen;
++
++	alen = 4 + 2 + len;
++	buf = os_malloc(alen);
++	if (buf == NULL)
++		return 0;
++	pos = buf;
++	WPA_PUT_BE32(pos, RADIUS_VENDOR_ID_COMCAST);
++	pos += 4;
++	*pos++ = subtype;
++	*pos++ = 2 + len;
++	os_memcpy(pos, data, len);
++	attr = radius_msg_add_attr(msg, RADIUS_ATTR_VENDOR_SPECIFIC,
++				   buf, alen);
++	os_free(buf);
++	if (attr == NULL)
++		return 0;
++
++	return 1;
++}
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+\ No newline at end of file
+diff --git a/src/radius/radius.h b/src/radius/radius.h
+index 177c64a66..8ee3e0323 100644
+--- a/src/radius/radius.h
++++ b/src/radius/radius.h
+@@ -232,6 +232,19 @@ enum {
+ 	RADIUS_VENDOR_ATTR_WFA_HS20_T_C_URL = 10,
+ };
+ 
++/* RDK Greylist: Comcast Vendor-specific Attributes */
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++#define RADIUS_VENDOR_ID_COMCAST 17270
++
++enum {
++	RADIUS_VENDOR_ATTR_COMCAST_NETWORK_TYPE = 133,
++	RADIUS_VENDOR_ATTR_COMCAST_CM_MAC = 134,
++	RADIUS_VENDOR_ATTR_COMCAST_AP_SNR = 136,
++	RADIUS_VENDOR_ATTR_COMCAST_REPLY_MESSAGE = 137,
++	RADIUS_VENDOR_ATTR_COMCAST_AP_VLAN_32 = 141,
++	RADIUS_VENDOR_ATTR_COMCAST_CONNECTED_BUILDING = 143,
++};
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ #ifdef _MSC_VER
+ #pragma pack(pop)
+ #endif /* _MSC_VER */
+@@ -370,4 +383,12 @@ u8 radius_msg_find_unlisted_attr(struct radius_msg *msg, u8 *attrs);
+ 
+ int radius_gen_session_id(u8 *id, size_t len);
+ 
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++u8 *radius_msg_get_vendor_attr(struct radius_msg *msg, u32 vendor,
++				u8 subtype, size_t *alen);
++
++int radius_msg_add_comcast(struct radius_msg *msg, u8 subtype, const u8 *data,
++			   size_t len);
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
++
+ #endif /* RADIUS_H */
+diff --git a/src/radius/radius_das.c b/src/radius/radius_das.c
+index aaa3fc267..4f9a575c4 100644
+--- a/src/radius/radius_das.c
++++ b/src/radius/radius_das.c
+@@ -429,6 +429,9 @@ static void radius_das_receive(int sock, void *eloop_ctx, void *sock_ctx)
+ 	if (wpa_debug_level <= MSG_MSGDUMP)
+ 		radius_msg_dump(msg);
+ 
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++	if (das->shared_secret) {
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 	if (radius_msg_verify_das_req(msg, das->shared_secret,
+ 				       das->shared_secret_len,
+ 				       das->require_message_authenticator)) {
+@@ -437,7 +440,9 @@ static void radius_das_receive(int sock, void *eloop_ctx, void *sock_ctx)
+ 			   abuf, from_port);
+ 		goto fail;
+ 	}
+-
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++	}
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 	os_get_time(&now);
+ 	res = radius_msg_get_attr(msg, RADIUS_ATTR_EVENT_TIMESTAMP,
+ 				  (u8 *) &val, 4);
+@@ -483,13 +488,18 @@ static void radius_das_receive(int sock, void *eloop_ctx, void *sock_ctx)
+ 				   "Event-Timestamp attribute");
+ 		}
+ 
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++		if (das->shared_secret) {
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 		if (radius_msg_finish_das_resp(reply, das->shared_secret,
+ 					       das->shared_secret_len, hdr) <
+ 		    0) {
+ 			wpa_printf(MSG_DEBUG, "DAS: Failed to add "
+ 				   "Message-Authenticator attribute");
+ 		}
+-
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++		}
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 		if (wpa_debug_level <= MSG_MSGDUMP)
+ 			radius_msg_dump(reply);
+ 
+@@ -513,6 +523,9 @@ static int radius_das_open_socket(int port)
+ {
+ 	int s;
+ 	struct sockaddr_in addr;
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++	int flag = 1;
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 
+ 	s = socket(PF_INET, SOCK_DGRAM, 0);
+ 	if (s < 0) {
+@@ -523,6 +536,11 @@ static int radius_das_open_socket(int port)
+ 	os_memset(&addr, 0, sizeof(addr));
+ 	addr.sin_family = AF_INET;
+ 	addr.sin_port = htons(port);
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++	if (-1 == setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag))) {
++		wpa_printf(MSG_DEBUG, "RADIUS DAS: setsockopt fail");
++	}
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 	if (bind(s, (struct sockaddr *) &addr, sizeof(addr)) < 0) {
+ 		wpa_printf(MSG_INFO, "RADIUS DAS: bind: %s", strerror(errno));
+ 		close(s);
+@@ -537,9 +555,14 @@ struct radius_das_data *
+ radius_das_init(struct radius_das_conf *conf)
+ {
+ 	struct radius_das_data *das;
+-
++	/* RADIUS greylist allows das secret to be null for open ssid */
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++	if (conf->port == 0 || conf->client_addr == NULL)
++#else /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 	if (conf->port == 0 || conf->shared_secret == NULL ||
+ 	    conf->client_addr == NULL)
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
++
+ 		return NULL;
+ 
+ 	das = os_zalloc(sizeof(*das));
+@@ -556,6 +579,9 @@ radius_das_init(struct radius_das_conf *conf)
+ 
+ 	os_memcpy(&das->client_addr, conf->client_addr,
+ 		  sizeof(das->client_addr));
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++	if (conf->shared_secret) {
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 
+ 	das->shared_secret = os_memdup(conf->shared_secret,
+ 				       conf->shared_secret_len);
+@@ -564,6 +590,9 @@ radius_das_init(struct radius_das_conf *conf)
+ 		return NULL;
+ 	}
+ 	das->shared_secret_len = conf->shared_secret_len;
++#ifdef FEATURE_SUPPORT_RADIUSGREYLIST
++	}
++#endif /* FEATURE_SUPPORT_RADIUSGREYLIST */
+ 
+ 	das->sock = radius_das_open_socket(conf->port);
+ 	if (das->sock < 0) {
+diff --git a/src/utils/crc32.c b/src/utils/crc32.c
+index 12d9e2a70..371254994 100644
+--- a/src/utils/crc32.c
++++ b/src/utils/crc32.c
+@@ -72,7 +72,7 @@ static const u32 crc32_table[256] = {
+ };
+ 
+ 
+-u32 crc32(const u8 *frame, size_t frame_len)
++u32 ieee80211_crc32(const u8 *frame, size_t frame_len)
+ {
+ 	size_t i;
+ 	u32 crc;
+diff --git a/src/utils/crc32.h b/src/utils/crc32.h
+index dc31399be..f92a7a9f2 100644
+--- a/src/utils/crc32.h
++++ b/src/utils/crc32.h
+@@ -9,6 +9,9 @@
+ #ifndef CRC32_H
+ #define CRC32_H
+ 
+-u32 crc32(const u8 *frame, size_t frame_len);
++/* crc32 conflicts with zlib crc32 */
++#define crc32 ieee80211_crc32
++
++u32 ieee80211_crc32(const u8 *frame, size_t frame_len);
+ 
+ #endif /* CRC32_H */
+diff --git a/src/utils/eloop.c b/src/utils/eloop.c
+index 00b0beff0..286cce099 100644
+--- a/src/utils/eloop.c
++++ b/src/utils/eloop.c
+@@ -555,6 +555,8 @@ static void eloop_sock_table_dispatch(struct eloop_sock_table *readers,
+ 				      struct pollfd **pollfds_map,
+ 				      int max_pollfd_map)
+ {
++	if (eloop.terminate)
++		return;
+ 	if (eloop_sock_table_dispatch_table(readers, pollfds_map,
+ 					    max_pollfd_map, POLLIN | POLLERR |
+ 					    POLLHUP))
+@@ -609,6 +611,56 @@ static void eloop_sock_table_dispatch(struct eloop_sock_table *table,
+ 	}
+ }
+ 
++int eloop_sock_table_read_set_fds(fd_set *fds)
++{
++	int i;
++
++	if (eloop.readers.table == NULL)
++		return 0;
++
++	for (i = 0; i < eloop.readers.count; i++) {
++		assert(eloop.readers.table[i].sock >= 0);
++		FD_SET(eloop.readers.table[i].sock, fds);
++	}
++	return 0;
++}
++
++int eloop_sock_table_read_get_biggest_fd(void)
++{
++	int i;
++	int sock_fd = 0;
++
++	if (eloop.readers.table == NULL)
++		return 0;
++
++	for (i = 0; i < eloop.readers.count; i++) {
++		assert(eloop.readers.table[i].sock >= 0);
++		if(sock_fd < eloop.readers.table[i].sock) {
++			sock_fd = eloop.readers.table[i].sock;
++		}
++	}
++	return sock_fd;
++}
++
++void eloop_sock_table_read_dispatch(fd_set *fds)
++{
++	int i;
++
++	if (eloop.readers.table == NULL)
++		return;
++
++	eloop.readers.changed = 0;
++	for (i = 0; i < eloop.readers.count; i++) {
++		if (FD_ISSET(eloop.readers.table[i].sock, fds)) {
++			eloop.readers.table[i].handler(eloop.readers.table[i].sock,
++						eloop.readers.table[i].eloop_data,
++						eloop.readers.table[i].user_data);
++			if (eloop.readers.changed)
++				break;
++		}
++	}
++}
++
+ #endif /* CONFIG_ELOOP_SELECT */
+ 
+ 
+@@ -962,6 +1014,58 @@ int eloop_replenish_timeout(unsigned int req_secs, unsigned int req_usecs,
+ 	return -1;
+ }
+ 
++int eloop_get_timeout_ms(void)
++{
++	struct eloop_timeout *timeout;
++	struct os_reltime tv, now;
++	int timeout_ms = -1;
++
++	if(dl_list_empty(&eloop.timeout))
++	{
++		return timeout_ms;
++	}
++
++	timeout = dl_list_first(&eloop.timeout, struct eloop_timeout,
++					list);
++	if (timeout) {
++		os_get_reltime(&now);
++		if (os_reltime_before(&now, &timeout->time))
++			os_reltime_sub(&timeout->time, &now, &tv);
++		else
++			tv.sec = tv.usec = 0;
++		timeout_ms = tv.sec * 1000 + tv.usec / 1000;
++	}
++	return timeout_ms;
++}
++
++int eloop_timeout_run(void)
++{
++	struct eloop_timeout *timeout;
++	struct os_reltime tv, now;
++
++	if(dl_list_empty(&eloop.timeout))
++	{
++		return 0;
++	}
++
++	/* check if some registered timeouts have occurred */
++	timeout = dl_list_first(&eloop.timeout, struct eloop_timeout,
++				list);
++	if (timeout) {
++		os_get_reltime(&now);
++		if (!os_reltime_before(&now, &timeout->time)) {
++			void *eloop_data = timeout->eloop_data;
++			void *user_data = timeout->user_data;
++			eloop_timeout_handler handler =
++				timeout->handler;
++			eloop_remove_timeout(timeout);
++                        printf("Executing callback\n");
++			handler(eloop_data, user_data);
++		}
++
++	}
++	return 0;
++}
+ 
+ #ifndef CONFIG_NATIVE_WINDOWS
+ static void eloop_handle_alarm(int sig)
+@@ -1185,6 +1289,8 @@ void eloop_run(void)
+ 			goto out;
+ 		}
+ 
++		if (eloop.terminate)
++			break;
+ 		eloop.readers.changed = 0;
+ 		eloop.writers.changed = 0;
+ 		eloop.exceptions.changed = 0;
+diff --git a/src/utils/eloop.h b/src/utils/eloop.h
+index 04ee6d183..b444e49fc 100644
+--- a/src/utils/eloop.h
++++ b/src/utils/eloop.h
+@@ -128,6 +128,10 @@ int eloop_register_sock(int sock, eloop_event_type type,
+  */
+ void eloop_unregister_sock(int sock, eloop_event_type type);
+ 
++int eloop_sock_table_read_set_fds(fd_set *fds);
++int eloop_sock_table_read_get_biggest_fd(void);
++void eloop_sock_table_read_dispatch(fd_set *fds);
++
+ /**
+  * eloop_register_event - Register handler for generic events
+  * @event: Event to wait (eloop implementation specific)
+@@ -255,6 +259,8 @@ int eloop_deplete_timeout(unsigned int req_secs, unsigned int req_usecs,
+ int eloop_replenish_timeout(unsigned int req_secs, unsigned int req_usecs,
+ 			    eloop_timeout_handler handler, void *eloop_data,
+ 			    void *user_data);
++int eloop_get_timeout_ms(void);
++int eloop_timeout_run(void);
+ 
+ /**
+  * eloop_register_signal - Register handler for signals
+diff --git a/src/utils/wpa_debug.c b/src/utils/wpa_debug.c
+index a338a2039..97ba248cc 100644
+--- a/src/utils/wpa_debug.c
++++ b/src/utils/wpa_debug.c
+@@ -210,6 +210,24 @@ void wpa_printf(int level, const char *fmt, ...)
+ {
+ 	va_list ap;
+ 
++    FILE *fpg = NULL;
++
++    va_start(ap, fmt);
++
++    if ((access("/nvram/wifiLibhostapDbg", R_OK)) == 0) {
++        fpg = fopen("/tmp/wifilibhostap", "a+");
++        if (fpg == NULL) {
++            return;
++        }
++
++        vfprintf(fpg, fmt, ap);
++        va_end(ap);
++        fprintf(fpg, "\n");
++        fflush(fpg);
++        fclose(fpg);
++        va_start(ap, fmt);
++    }
++
+ 	if (level >= wpa_debug_level) {
+ #ifdef CONFIG_ANDROID_LOG
+ 		va_start(ap, fmt);
+@@ -226,6 +244,10 @@ void wpa_printf(int level, const char *fmt, ...)
+ #endif /* CONFIG_DEBUG_SYSLOG */
+ 		wpa_debug_print_timestamp();
+ #ifdef CONFIG_DEBUG_FILE
++		if ((access("/nvram/wifiHostapDbg", R_OK)) != 0 &&
++			(access("/nvram/wifiHostapDbg2", R_OK)) != 0) {
++			return;
++		}
+ 		if (out_file) {
+ 			va_start(ap, fmt);
+ 			vfprintf(out_file, fmt, ap);
+@@ -259,7 +281,28 @@ static void _wpa_hexdump(int level, const char *title, const u8 *buf,
+ 			 size_t len, int show, int only_syslog)
+ {
+ 	size_t i;
++	static FILE *fpg = NULL;
++
++	if ((access("/nvram/wifiLibhostapDbg", R_OK)) == 0) {
++		if (fpg == NULL) {
++			fpg = fopen("/tmp/wifilibhostap", "a+");
++			if (fpg == NULL) {
++				return;
++			}
++		}
+ 
++		fprintf(fpg, "%s - hexdump(len=%lu):", title, (unsigned long) len);
++
++		if (buf == NULL) {
++		fprintf(fpg, " [NULL]");
++		} else {
++		for (i = 0; i < len; i++)
++			fprintf(fpg, " %02x", buf[i]);
++		}
++
++		fprintf(fpg, "\n");
++		fflush(fpg);
++}
+ #ifdef CONFIG_DEBUG_LINUX_TRACING
+ 	if (wpa_debug_tracing_file != NULL) {
+ 		fprintf(wpa_debug_tracing_file,
+@@ -353,6 +396,10 @@ static void _wpa_hexdump(int level, const char *title, const u8 *buf,
+ #endif /* CONFIG_DEBUG_SYSLOG */
+ 	wpa_debug_print_timestamp();
+ #ifdef CONFIG_DEBUG_FILE
++	if ((access("/nvram/wifiHostapDbg", R_OK) != 0) &&
++		(access("/nvram/wifiHostapDbg2", R_OK)) != 0) {
++		return;
++	}
+ 	if (out_file) {
+ 		fprintf(out_file, "%s - hexdump(len=%lu):",
+ 			title, (unsigned long) len);
+@@ -551,6 +598,13 @@ int wpa_debug_reopen_file(void)
+ int wpa_debug_open_file(const char *path)
+ {
+ #ifdef CONFIG_DEBUG_FILE
++	wpa_debug_timestamp++;
++
++	if ((access("/nvram/wifiHostapDbg", R_OK)) == 0)
++		wpa_debug_level = MSG_DEBUG;
++	else if ((access("/nvram/wifiHostapDbg2", R_OK)) == 0)
++		wpa_debug_level = MSG_EXCESSIVE;
++
+ 	int out_fd;
+ 
+ 	if (!path)
+@@ -846,10 +900,10 @@ void hostapd_logger(void *ctx, const u8 *addr, unsigned int module, int level,
+ 	if (hostapd_logger_cb)
+ 		hostapd_logger_cb(ctx, addr, module, level, buf, len);
+ 	else if (addr)
+-		wpa_printf(MSG_DEBUG, "hostapd_logger: STA " MACSTR " - %s",
++		wpa_printf(MSG_INFO, "hostapd_logger: STA " MACSTR " - %s",
+ 			   MAC2STR(addr), buf);
+ 	else
+-		wpa_printf(MSG_DEBUG, "hostapd_logger: %s", buf);
++		wpa_printf(MSG_INFO, "hostapd_logger: %s", buf);
+ 	bin_clear_free(buf, buflen);
+ }
+ #endif /* CONFIG_NO_HOSTAPD_LOGGER */
+diff --git a/src/wps/http_server.c b/src/wps/http_server.c
+index 507abe870..8ccad3f85 100644
+--- a/src/wps/http_server.c
++++ b/src/wps/http_server.c
+@@ -244,7 +244,12 @@ struct http_server * http_server_init(struct in_addr *addr, int port,
+ 	if (srv->fd < 0)
+ 		goto fail;
+ 
++#if defined(CONFIG_DRIVER_BRCM) && !defined(CMWIFI)
++	//CMWIFI to upgrade toolchain to have SO_RESUEPORT
++	if (setsockopt(srv->fd, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, &on, sizeof(on)) < 0)
++#else
+ 	if (setsockopt(srv->fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) < 0)
++#endif /* CONFIG_DRIVER_BRCM */
+ 	{
+ 		wpa_printf(MSG_DEBUG,
+ 			   "HTTP: setsockopt(SO_REUSEADDR) failed: %s",
+diff --git a/src/wps/wps.h b/src/wps/wps.h
+index fed3e2848..ff3ca4da9 100644
+--- a/src/wps/wps.h
++++ b/src/wps/wps.h
+@@ -484,6 +484,21 @@ enum wps_event {
+ 	 */
+ 	WPS_EV_PBC_DISABLE,
+ 
++	/**
++	 * WPS_EV_PIN_TIMEOUT - PIN session was expired
++	 */
++	WPS_EV_PIN_TIMEOUT,
++
++	/**
++	 * WPS_EV_PIN_DISABLE - PIN session was disabled
++	 */
++	WPS_EV_PIN_DISABLE,
++
++	/**
++	 * WPS_EV_PIN_ACTIVE - PIN mode was activated
++	 */
++	WPS_EV_PIN_ACTIVE,
++
+ 	/**
+ 	 * WPS_EV_ER_AP_ADD - ER: AP added
+ 	 */
+@@ -841,7 +856,10 @@ struct wps_context {
+ 	struct wpabuf *ap_nfc_dh_pubkey;
+ 	struct wpabuf *ap_nfc_dh_privkey;
+ 	struct wpabuf *ap_nfc_dev_pw;
+-
++#ifdef CONFIG_DRIVER_BRCM_MAP
++    u8 map;
++    struct wps_credential bh_creds; /* Multiap backhaul credentials */
++#endif  /* CONFIG_DRIVER_BRCM_MAP */
+ 	/* Whether to send WPA2-PSK passphrase as a passphrase instead of PSK
+ 	 * for WPA3-Personal transition mode needs. */
+ 	bool use_passphrase;
+diff --git a/src/wps/wps_attr_parse.c b/src/wps/wps_attr_parse.c
+index fd5163515..02eb87715 100644
+--- a/src/wps/wps_attr_parse.c
++++ b/src/wps/wps_attr_parse.c
+@@ -67,6 +67,15 @@ static int wps_set_vendor_ext_wfa_subelem(struct wps_parse_attr *attr,
+ 		}
+ 		attr->registrar_configuration_methods = pos;
+ 		break;
++#ifdef CONFIG_DRIVER_BRCM_MAP
++        case WFA_ELEM_MAP_EXTENSION_ATTR:
++                if (len < 1) {
++                        wpa_printf(MSG_DEBUG, "WPS: Invalid multiap extension attr %u", len);
++                        return -1;
++                }
++                attr->map_ext_attr = pos;
++                break;
++#else
+ 	case WFA_ELEM_MULTI_AP:
+ 		if (len != 1) {
+ 			wpa_printf(MSG_DEBUG,
+@@ -78,6 +87,7 @@ static int wps_set_vendor_ext_wfa_subelem(struct wps_parse_attr *attr,
+ 		wpa_printf(MSG_DEBUG, "WPS: Multi-AP Extension 0x%02x",
+ 			   attr->multi_ap_ext);
+ 		break;
++#endif  /* CONFIG_DRIVER_BRCM_MAP */
+ 	default:
+ 		wpa_printf(MSG_MSGDUMP, "WPS: Skipped unknown WFA Vendor "
+ 			   "Extension subelement %u", id);
+diff --git a/src/wps/wps_attr_parse.h b/src/wps/wps_attr_parse.h
+index 4de27b26d..c95335069 100644
+--- a/src/wps/wps_attr_parse.h
++++ b/src/wps/wps_attr_parse.h
+@@ -56,6 +56,9 @@ struct wps_parse_attr {
+ 	const u8 *request_to_enroll; /* 1 octet (Bool) */
+ 	const u8 *ap_channel; /* 2 octets */
+ 	const u8 *registrar_configuration_methods; /* 2 octets */
++#ifdef CONFIG_DRIVER_BRCM_MAP
++    const u8 *map_ext_attr; /* 1 octet */
++#endif  /* CONFIG_DRIVER_BRCM_MAP */
+ 
+ 	/* variable length fields */
+ 	const u8 *manufacturer;
+diff --git a/src/wps/wps_common.c b/src/wps/wps_common.c
+index 747dc4710..a8747cece 100644
+--- a/src/wps/wps_common.c
++++ b/src/wps/wps_common.c
+@@ -351,6 +351,33 @@ void wps_pbc_disable_event(struct wps_context *wps)
+ }
+ 
+ 
++void wps_pin_timeout_event(struct wps_context *wps)
++{
++	if (wps->event_cb == NULL)
++		return;
++
++	wps->event_cb(wps->cb_ctx, WPS_EV_PIN_TIMEOUT, NULL);
++}
++
++
++void wps_pin_active_event(struct wps_context *wps)
++{
++	if (wps->event_cb == NULL)
++		return;
++
++	wps->event_cb(wps->cb_ctx, WPS_EV_PIN_ACTIVE, NULL);
++}
++
++
++void wps_pin_disable_event(struct wps_context *wps)
++{
++	if (wps->event_cb == NULL)
++		return;
++
++	wps->event_cb(wps->cb_ctx, WPS_EV_PIN_DISABLE, NULL);
++}
++
++
+ #ifdef CONFIG_WPS_OOB
+ 
+ struct wpabuf * wps_get_oob_cred(struct wps_context *wps, int rf_band,
+diff --git a/src/wps/wps_defs.h b/src/wps/wps_defs.h
+index ddaeda56d..a19424329 100644
+--- a/src/wps/wps_defs.h
++++ b/src/wps/wps_defs.h
+@@ -153,7 +153,10 @@ enum {
+ 	WFA_ELEM_REQUEST_TO_ENROLL = 0x03,
+ 	WFA_ELEM_SETTINGS_DELAY_TIME = 0x04,
+ 	WFA_ELEM_REGISTRAR_CONFIGURATION_METHODS = 0x05,
+-	WFA_ELEM_MULTI_AP = 0x06
++	WFA_ELEM_MULTI_AP = 0x06,
++#ifdef CONFIG_DRIVER_BRCM_MAP
++    WFA_ELEM_MAP_EXTENSION_ATTR = 0x06,
++#endif  /* CONFIG_DRIVER_BRCM_MAP */
+ };
+ 
+ /* Device Password ID */
+@@ -381,4 +384,9 @@ enum wps_response_type {
+ 
+ #define WPS_MAX_AUTHORIZED_MACS 5
+ 
++#ifdef CONFIG_DRIVER_BRCM_MAP
++#define WPS_MAP_BH_STA          0x80
++#define WPS_MAP_FH_BSS          0x20
++#endif  /* CONFIG_DRIVER_BRCM_MAP */
++
+ #endif /* WPS_DEFS_H */
+diff --git a/src/wps/wps_i.h b/src/wps/wps_i.h
+index 2cf22d4b7..ae9309ac5 100644
+--- a/src/wps/wps_i.h
++++ b/src/wps/wps_i.h
+@@ -127,6 +127,9 @@ struct wps_data {
+ 	struct wps_nfc_pw_token *nfc_pw_token;
+ 
+ 	int multi_ap_backhaul_sta;
++#ifdef CONFIG_DRIVER_BRCM_MAP
++        u8 map_ext_attr_e;              /* Enrolee multiap extension attribute */
++#endif  /* CONFIG_DRIVER_BRCM_MAP */
+ };
+ 
+ 
+@@ -148,6 +151,10 @@ void wps_pbc_timeout_event(struct wps_context *wps);
+ void wps_pbc_active_event(struct wps_context *wps);
+ void wps_pbc_disable_event(struct wps_context *wps);
+ 
++void wps_pin_timeout_event(struct wps_context *wps);
++void wps_pin_active_event(struct wps_context *wps);
++void wps_pin_disable_event(struct wps_context *wps);
++
+ struct wpabuf * wps_build_wsc_ack(struct wps_data *wps);
+ struct wpabuf * wps_build_wsc_nack(struct wps_data *wps);
+ 
+diff --git a/src/wps/wps_registrar.c b/src/wps/wps_registrar.c
+index 9587293d0..257ed56e1 100644
+--- a/src/wps/wps_registrar.c
++++ b/src/wps/wps_registrar.c
+@@ -230,6 +230,8 @@ static void wps_registrar_set_selected_timeout(void *eloop_ctx,
+ static void wps_registrar_remove_pin(struct wps_registrar *reg,
+ 				     struct wps_uuid_pin *pin);
+ 
++static void wps_registrar_pbc_completed(struct wps_registrar *reg);
++static void wps_registrar_pin_completed(struct wps_registrar *reg);
+ 
+ static void wps_registrar_add_authorized_mac(struct wps_registrar *reg,
+ 					     const u8 *addr)
+@@ -748,6 +750,16 @@ void wps_registrar_deinit(struct wps_registrar *reg)
+ {
+ 	if (reg == NULL)
+ 		return;
++
++	wpa_printf(MSG_DEBUG, "WPS: Deinit registar: PBC: %d", reg->pbc);
++
++	// Make ensure that all WPS sessions were terminated
++	if (reg->pbc) {
++		wps_registrar_pbc_completed(reg);
++	} else if (reg->selected_registrar) {
++		wps_registrar_pin_completed(reg);
++	}
++
+ 	eloop_cancel_timeout(wps_registrar_pbc_timeout, reg, NULL);
+ 	eloop_cancel_timeout(wps_registrar_set_selected_timeout, reg, NULL);
+ 	wps_registrar_flush(reg);
+@@ -832,6 +844,7 @@ int wps_registrar_add_pin(struct wps_registrar *reg, const u8 *addr,
+ 	eloop_register_timeout(WPS_PBC_WALK_TIME, 0,
+ 			       wps_registrar_set_selected_timeout,
+ 			       reg, NULL);
++	wps_pin_active_event(reg->wps);
+ 
+ 	return 0;
+ }
+@@ -1074,7 +1087,7 @@ int wps_registrar_button_pushed(struct wps_registrar *reg,
+ }
+ 
+ 
+-static void wps_registrar_pbc_completed(struct wps_registrar *reg)
++void wps_registrar_pbc_completed(struct wps_registrar *reg)
+ {
+ 	wpa_printf(MSG_DEBUG, "WPS: PBC completed - stopping PBC mode");
+ 	eloop_cancel_timeout(wps_registrar_pbc_timeout, reg, NULL);
+@@ -1083,7 +1096,7 @@ static void wps_registrar_pbc_completed(struct wps_registrar *reg)
+ }
+ 
+ 
+-static void wps_registrar_pin_completed(struct wps_registrar *reg)
++void wps_registrar_pin_completed(struct wps_registrar *reg)
+ {
+ 	wpa_printf(MSG_DEBUG, "WPS: PIN completed using internal Registrar");
+ 	eloop_cancel_timeout(wps_registrar_set_selected_timeout, reg, NULL);
+@@ -1128,6 +1141,7 @@ int wps_registrar_wps_cancel(struct wps_registrar *reg)
+ 		wpa_printf(MSG_DEBUG, "WPS: PIN is set - cancelling it");
+ 		wps_registrar_pin_completed(reg);
+ 		wps_registrar_invalidate_wildcard_pin(reg, NULL, 0);
++		wps_pin_disable_event(reg->wps);
+ 		return 1;
+ 	}
+ 	return 0;
+@@ -1632,7 +1646,20 @@ int wps_build_cred(struct wps_data *wps, struct wpabuf *msg)
+ 		goto use_provided;
+ 	}
+ 	os_memset(&wps->cred, 0, sizeof(wps->cred));
+-
++#ifdef CONFIG_DRIVER_BRCM_MAP
++        /* For multiap backhaul sta use the backhaul ssid and password */
++        if ((wps->map_ext_attr_e == WPS_MAP_BH_STA) && (wps->wps->map & WPS_MAP_FH_BSS) &&
++                        wps->wps->bh_creds.ssid_len > 0) {
++                os_memcpy(wps->cred.ssid, wps->wps->bh_creds.ssid, wps->wps->bh_creds.ssid_len);
++                wps->cred.ssid_len = wps->wps->bh_creds.ssid_len;
++                wps->cred.auth_type = wps->wps->bh_creds.auth_type;
++                wps->cred.encr_type = wps->wps->bh_creds.encr_type;
++                os_memcpy(wps->cred.mac_addr, wps->mac_addr_e, ETH_ALEN);
++                os_memcpy(wps->cred.key, wps->wps->bh_creds.key, wps->wps->bh_creds.key_len);
++                wps->cred.key_len = wps->wps->bh_creds.key_len;
++                goto use_provided;
++        }
++#else
+ 	if (wps->peer_dev.multi_ap_ext == MULTI_AP_BACKHAUL_STA &&
+ 	    reg->multi_ap_backhaul_ssid_len) {
+ 		wpa_printf(MSG_DEBUG, "WPS: Use backhaul STA credentials");
+@@ -1655,7 +1682,7 @@ int wps_build_cred(struct wps_data *wps, struct wpabuf *msg)
+ 		}
+ 		goto use_provided;
+ 	}
+-
++#endif  /* CONFIG_DRIVER_BRCM_MAP */
+ 	os_memcpy(wps->cred.ssid, wps->wps->ssid, wps->wps->ssid_len);
+ 	wps->cred.ssid_len = wps->wps->ssid_len;
+ 
+@@ -2602,6 +2629,21 @@ static int wps_process_config_error(struct wps_data *wps, const u8 *err)
+ 	return 0;
+ }
+ 
++#ifdef CONFIG_DRIVER_BRCM_MAP
++static int wps_process_map_ext_attr(struct wps_data *wps, const u8 *map)
++{
++        if (map == NULL) {
++                wpa_printf(MSG_DEBUG, "WPS: No multiap extension attribute received");
++                wps->map_ext_attr_e = 0;
++                return 0;
++        }
++
++        wps->map_ext_attr_e = *map;
++        wpa_printf(MSG_DEBUG, "WPS: Enrollee Multiap Extension Attr %d", wps->map_ext_attr_e);
++
++        return 0;
++}
++#endif  /* CONFIG_DRIVER_BRCM_MAP */
+ 
+ static int wps_registrar_p2p_dev_addr_match(struct wps_data *wps)
+ {
+@@ -2667,7 +2709,11 @@ static enum wps_process_res wps_process_m1(struct wps_data *wps,
+ 	    wps_process_assoc_state(wps, attr->assoc_state) ||
+ 	    wps_process_dev_password_id(wps, attr->dev_password_id) ||
+ 	    wps_process_config_error(wps, attr->config_error) ||
+-	    wps_process_os_version(&wps->peer_dev, attr->os_version))
++	    wps_process_os_version(&wps->peer_dev, attr->os_version) ||
++#ifdef CONFIG_DRIVER_BRCM_MAP
++            wps_process_map_ext_attr(wps, attr->map_ext_attr) ||
++#endif  /* CONFIG_DRIVER_BRCM_MAP */
++		0 )
+ 		return WPS_FAILURE;
+ 
+ 	if (wps->dev_pw_id < 0x10 &&
+@@ -3474,6 +3520,7 @@ static void wps_registrar_set_selected_timeout(void *eloop_ctx,
+ 	reg->pbc = 0;
+ 	wps_registrar_expire_pins(reg);
+ 	wps_registrar_selected_registrar_changed(reg, 0);
++	wps_pin_timeout_event(reg->wps);
+ }
+ 
+ 
+diff --git a/src/wps/wps_upnp.c b/src/wps/wps_upnp.c
+index 05bb9c585..22c6037d5 100644
+--- a/src/wps/wps_upnp.c
++++ b/src/wps/wps_upnp.c
+@@ -184,7 +184,9 @@
+ #include "wps_i.h"
+ #include "wps_upnp.h"
+ #include "wps_upnp_i.h"
+-
++#ifdef CONFIG_DRIVER_BRCM
++#include <assert.h>
++#endif	/* CONFIG_DRIVER_BRCM */
+ 
+ /*
+  * UPnP allows a client ("control point") to send a server like us ("device")
+@@ -212,9 +214,39 @@
+ /* Maximum number of Probe Request events per second */
+ #define MAX_EVENTS_PER_SEC 5
+ 
+-
++#ifndef CONFIG_DRIVER_BRCM
+ static struct upnp_wps_device_sm *shared_upnp_device = NULL;
++#else
++#define MAX_SHARED_DEV	16
++static struct upnp_wps_device_sm **shared_upnp_device = NULL;
++static struct upnp_wps_device_sm *upnp_devices[MAX_SHARED_DEV] = {NULL};
++static struct upnp_wps_device_sm **get_shared_upnp_device(char *net_if)
++{
++	int idx = 0;
++	struct upnp_wps_device_sm **upnp_device = NULL;
+ 
++	if (!net_if) {
++		wpa_printf(MSG_ERROR, "WPS UPnP: %s unexpected net_if \n", __func__);
++		return &upnp_devices[MAX_SHARED_DEV - 1];
++	}
++
++	while (idx < MAX_SHARED_DEV && upnp_devices[idx] != NULL &&
++			upnp_devices[idx]->upnp_iface != NULL) {
++		if (!os_strcmp(net_if, upnp_devices[idx]->upnp_iface)) {
++			upnp_device = &upnp_devices[idx];
++			break;
++		}
++		idx++;
++	}
++
++	assert(idx < MAX_SHARED_DEV);
++
++	if (!upnp_device)
++		upnp_device = &upnp_devices[idx];
++
++	return upnp_device;
++}
++#endif	/* CONFIG_DRIVER_BRCM */
+ 
+ /* Write the current date/time per RFC */
+ void format_date(struct wpabuf *buf)
+@@ -1044,6 +1076,10 @@ static void upnp_wps_device_stop(struct upnp_wps_device_sm *sm)
+  */
+ static int upnp_wps_device_start(struct upnp_wps_device_sm *sm, char *net_if)
+ {
++#ifdef CONFIG_DRIVER_BRCM
++	int failed = 0;
++#endif	/* CONFIG_DRIVER_BRCM */
++
+ 	if (!sm || !net_if)
+ 		return -1;
+ 
+@@ -1054,6 +1090,9 @@ static int upnp_wps_device_start(struct upnp_wps_device_sm *sm, char *net_if)
+ 	sm->ssdp_sd = -1;
+ 	sm->started = 1;
+ 	sm->advertise_count = 0;
++#ifdef CONFIG_DRIVER_BRCM
++	sm->upnp_iface = os_strdup(net_if);
++#endif /* CONFIG_DRIVER_BRCM */
+ 
+ 	/* Fix up linux multicast handling */
+ 	if (add_ssdp_network(net_if))
+@@ -1064,7 +1103,11 @@ static int upnp_wps_device_start(struct upnp_wps_device_sm *sm, char *net_if)
+ 			   &sm->netmask, sm->mac_addr)) {
+ 		wpa_printf(MSG_INFO, "WPS UPnP: Could not get IP/MAC address "
+ 			   "for %s. Does it have IP address?", net_if);
++#ifdef CONFIG_DRIVER_BRCM
++		failed = 1;
++#else
+ 		goto fail;
++#endif	/* CONFIG_DRIVER_BRCM */
+ 	}
+ 	wpa_printf(MSG_DEBUG, "WPS UPnP: Local IP address %s netmask %s hwaddr "
+ 		   MACSTR,
+@@ -1074,8 +1117,13 @@ static int upnp_wps_device_start(struct upnp_wps_device_sm *sm, char *net_if)
+ 	/* Listen for incoming TCP connections so that others
+ 	 * can fetch our "xml files" from us.
+ 	 */
++#ifdef CONFIG_DRIVER_BRCM
++	if (!failed &&  web_listener_start(sm))
++		goto fail;
++#else
+ 	if (web_listener_start(sm))
+ 		goto fail;
++#endif	/* CONFIG_DRIVER_BRCM */
+ 
+ 	/* Set up for receiving discovery (UDP) packets */
+ 	if (ssdp_listener_start(sm))
+@@ -1133,6 +1181,9 @@ void upnp_wps_device_deinit(struct upnp_wps_device_sm *sm, void *priv)
+ 			   "instance to deinit");
+ 		return;
+ 	}
++#ifdef CONFIG_DRIVER_BRCM
++	shared_upnp_device = get_shared_upnp_device(sm->upnp_iface);
++#endif	/* CONFIG_DRIVER_BRCM */
+ 	wpa_printf(MSG_DEBUG, "WPS UPnP: Deinit interface instance %p", iface);
+ 	if (dl_list_len(&sm->interfaces) == 1) {
+ 		wpa_printf(MSG_DEBUG, "WPS UPnP: Deinitializing last instance "
+@@ -1157,8 +1208,16 @@ void upnp_wps_device_deinit(struct upnp_wps_device_sm *sm, void *priv)
+ 	if (dl_list_empty(&sm->interfaces)) {
+ 		os_free(sm->root_dir);
+ 		os_free(sm->desc_url);
++#ifdef CONFIG_DRIVER_BRCM
++		os_free(sm->upnp_iface);
++		sm->upnp_iface = NULL;
++#endif	/* CONFIG_DRIVER_BRCM */
+ 		os_free(sm);
++#ifdef CONFIG_DRIVER_BRCM
++		*shared_upnp_device = NULL;
++#else
+ 		shared_upnp_device = NULL;
++#endif	/* CONFIG_DRIVER_BRCM */
+ 	}
+ }
+ 
+@@ -1192,10 +1251,19 @@ upnp_wps_device_init(struct upnp_wps_device_ctx *ctx, struct wps_context *wps,
+ 	iface->wps = wps;
+ 	iface->priv = priv;
+ 
++#ifdef CONFIG_DRIVER_BRCM
++	shared_upnp_device = get_shared_upnp_device(net_if);
++	if (*shared_upnp_device) {
++#else
+ 	if (shared_upnp_device) {
++#endif	/* CONFIG_DRIVER_BRCM */
+ 		wpa_printf(MSG_DEBUG, "WPS UPnP: Share existing device "
+ 			   "context");
++#ifdef CONFIG_DRIVER_BRCM
++		sm = *shared_upnp_device;
++#else
+ 		sm = shared_upnp_device;
++#endif	/* CONFIG_DRIVER_BRCM */
+ 	} else {
+ 		wpa_printf(MSG_DEBUG, "WPS UPnP: Initialize device context");
+ 		sm = os_zalloc(sizeof(*sm));
+@@ -1207,7 +1275,11 @@ upnp_wps_device_init(struct upnp_wps_device_ctx *ctx, struct wps_context *wps,
+ 			os_free(ctx);
+ 			return NULL;
+ 		}
++#ifdef CONFIG_DRIVER_BRCM
++		*shared_upnp_device = sm;
++#else
+ 		shared_upnp_device = sm;
++#endif	/* CONFIG_DRIVER_BRCM */
+ 
+ 		dl_list_init(&sm->msearch_replies);
+ 		dl_list_init(&sm->subscriptions);
+@@ -1257,3 +1329,38 @@ int upnp_wps_set_ap_pin(struct upnp_wps_device_sm *sm, const char *ap_pin)
+ 
+ 	return 0;
+ }
++
++
++#ifdef CONFIG_DRIVER_BRCM
++/**
++ * upnp_wps_web_listener_sock_update - updates web listner socket
++ * @sm: WPS UPnP state machine from upnp_wps_device_init()
++ * @net_if: Selected network interface name
++ * Returns: 0 or -1 on failure
++ */
++int upnp_wps_web_listener_sock_update(struct upnp_wps_device_sm *sm, char *net_if)
++{
++	if (!sm || !net_if)
++		return -1;
++
++	web_listener_stop(sm);
++
++	/* Determine which IP and mac address we're using */
++	if (get_netif_info(net_if, &sm->ip_addr, &sm->ip_addr_text,
++			   &sm->netmask, sm->mac_addr)) {
++		wpa_printf(MSG_INFO, "WPS UPnP: Could not get IP address for %s", net_if);
++		goto fail;
++	}
++
++	/* Listen for incoming TCP connections so that others
++	 * can fetch our "xml files" from us.
++	 */
++	if (web_listener_start(sm))
++		goto fail;
++
++	return 0;
++fail:
++	upnp_wps_device_stop(sm);
++	return -1;
++}
++#endif	/* CONFIG_DRIVER_BRCM */
+\ No newline at end of file
+diff --git a/src/wps/wps_upnp.h b/src/wps/wps_upnp.h
+index b6f6df5ec..f49e0a136 100644
+--- a/src/wps/wps_upnp.h
++++ b/src/wps/wps_upnp.h
+@@ -47,5 +47,8 @@ int upnp_wps_device_send_wlan_event(struct upnp_wps_device_sm *sm,
+ 				    const struct wpabuf *msg);
+ int upnp_wps_subscribers(struct upnp_wps_device_sm *sm);
+ int upnp_wps_set_ap_pin(struct upnp_wps_device_sm *sm, const char *ap_pin);
++#ifdef CONFIG_DRIVER_BRCM
++int upnp_wps_web_listener_sock_update(struct upnp_wps_device_sm *sm, char *net_if);
++#endif	/* CONFIG_DRIVER_BRCM */
+ 
+ #endif /* WPS_UPNP_H */
+diff --git a/src/wps/wps_upnp_ap.c b/src/wps/wps_upnp_ap.c
+index b6c9478ff..98b6d2e7f 100644
+--- a/src/wps/wps_upnp_ap.c
++++ b/src/wps/wps_upnp_ap.c
+@@ -76,8 +76,11 @@ int upnp_er_set_selected_registrar(struct wps_registrar *reg,
+ void upnp_er_remove_notification(struct wps_registrar *reg,
+ 				 struct subscription *s)
+ {
++#ifndef CONFIG_DRIVER_BRCM
+ 	bool was_sel_reg = s->selected_registrar;
+-
++#else
++	u8 was_sel_reg = s->selected_registrar;
++#endif /* CONFIG_DRIVER_BRCM */
+ 	s->selected_registrar = 0;
+ 	eloop_cancel_timeout(upnp_er_set_selected_timeout, s, reg);
+ 	if (reg && was_sel_reg)
+diff --git a/src/wps/wps_upnp_i.h b/src/wps/wps_upnp_i.h
+index 6ead7b4e9..d2d82ecc6 100644
+--- a/src/wps/wps_upnp_i.h
++++ b/src/wps/wps_upnp_i.h
+@@ -146,6 +146,9 @@ struct upnp_wps_device_sm {
+ 	enum upnp_wps_wlanevent_type wlanevent_type;
+ 	os_time_t last_event_sec;
+ 	unsigned int num_events_in_sec;
++#ifdef CONFIG_DRIVER_BRCM
++	char *upnp_iface;
++#endif	/* CONFIG_DRIVER_BRCM */
+ };
+ 
+ /* wps_upnp.c */
+diff --git a/src/wps/wps_validate.c b/src/wps/wps_validate.c
+index 5c12bce25..1c10201d1 100644
+--- a/src/wps/wps_validate.c
++++ b/src/wps/wps_validate.c
+@@ -421,6 +421,24 @@ static int wps_validate_request_to_enroll(const u8 *request_to_enroll,
+ 	return 0;
+ }
+ 
++#ifdef CONFIG_DRIVER_BRCM_MAP
++static int wps_validate_map_ext_attr(const u8 *map_ext_attr, int mandatory)
++{
++        if (map_ext_attr == NULL) {
++                if (mandatory) {
++                        wpa_printf(MSG_INFO, "WPS-STRICT: multiap extension attribute missing");
++                        return -1;
++                }
++                return 0;
++        }
++        if (*map_ext_attr != WPS_MAP_BH_STA) {
++                wpa_printf(MSG_INFO, "WPS-STRICT: Invalid multiap extension "
++                           "attribute value 0x%x", *map_ext_attr);
++                return -1;
++        }
++        return 0;
++}
++#endif  /* CONFIG_DRIVER_BRCM_MAP */
+ 
+ static int wps_validate_req_dev_type(const u8 *req_dev_type[], size_t num,
+ 				     int mandatory)
+@@ -1324,7 +1342,11 @@ int wps_validate_m1(const struct wpabuf *tlvs)
+ 	    wps_validate_config_error(attr.config_error, 1) ||
+ 	    wps_validate_os_version(attr.os_version, 1) ||
+ 	    wps_validate_version2(attr.version2, wps2) ||
+-	    wps_validate_request_to_enroll(attr.request_to_enroll, 0)) {
++	    wps_validate_request_to_enroll(attr.request_to_enroll, 0) ||
++#ifdef CONFIG_DRIVER_BRCM_MAP
++        wps_validate_map_ext_attr(attr.map_ext_attr, 0) ||
++#endif  /* CONFIG_DRIVER_BRCM_MAP */
++            0) {
+ 		wpa_printf(MSG_INFO, "WPS-STRICT: Invalid M1");
+ #ifdef WPS_STRICT_WPS2
+ 		if (wps2)
+diff --git a/tests/.DS_Store b/tests/.DS_Store
+new file mode 100644
+index 000000000..e69de29bb
+diff --git a/wpa_supplicant/.DS_Store b/wpa_supplicant/.DS_Store
+new file mode 100644
+index 000000000..e69de29bb
+diff --git a/wpadebug/.DS_Store b/wpadebug/.DS_Store
+new file mode 100644
+index 000000000..e69de29bb
+-- 
+2.30.2
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,238 @@
+BSD 3-Clause License
+--------------------
+Copyright <YEAR> <COPYRIGHT HOLDER>
+
+This software may be distributed, used, and modified under the terms of
+BSD license:
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name(s) of the above-listed copyright holder(s) nor the
+   names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+“AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---------------
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # hostap-patches
 Maintains the patches for the upstream hostap component
+The patch 0001-OneWifi-related-hostap-patch-for-2.10-based-hostap.patch is a
+concatenation of patches from the below location 
+- https://code.rdkcentral.com/r/plugins/gitiles/rdk/components/generic/rdk-oe/meta-rdk-b[…]/heads/rdk-next/recipes-ccsp/rdk-wifi-libhostap/files/2.10/
+- https://code.rdkcentral.com/r/plugins/gitiles/rdk/components/generic/rdk-oe/meta-cmf-b[…]/refs/heads/rdk-next/recipes-ccsp/rdk-wifi-libhostap/files/
+- https://code.rdkcentral.com/r/plugins/gitiles/rdk/components/generic/rdk-oe/meta-cmf-r[…]-broadband/recipes-ccsp/rdk-wifi-libhostap/files?autodive=0
+The source of the patches are present in the original repositories above.
+The code here is licensed in the same way as of hostap.git i.e.
+BSD-3 license unless othewise indicated.
+
+Hostap is copyrighted as per
+Copyright(c) 2022-2022, Jouni Malinen j@w1.fi and contributors
+All Rights Reserved.


### PR DESCRIPTION
This patch consolidates all the required hostap changes on top of 2.10 version hostap. The base hostap checkout point is 9d07b9447e76059a2ddef2a879c57d0934634188 on which this patch can be applied.