### PR TITLE
RDKB-58414: Dynamically update NAS

### DIFF
--- a/Dynamic_NAS_IP_Update_2_10.patch
+++ b/Dynamic_NAS_IP_Update_2_10.patch
@@ -1,0 +1,323 @@
+diff --git a/source/hostap-2.10/hostapd/config_file.c b/source/hostap-2.10/hostapd/config_file.c
+index f616e3d..587c022 100644
+--- a/source/hostap-2.10/hostapd/config_file.c
++++ b/source/hostap-2.10/hostapd/config_file.c
+@@ -2688,7 +2688,7 @@ static int hostapd_config_fill(struct hostapd_config *conf,
+ 		wpa_printf(MSG_INFO, "DEPRECATED: iapp_interface not used");
+ #endif /* CONFIG_IAPP */
+ 	} else if (os_strcmp(buf, "own_ip_addr") == 0) {
+-		if (hostapd_parse_ip_addr(pos, &bss->own_ip_addr)) {
++		if (hostapd_parse_ip_addr(pos, &bss->radius->own_ip_addr)) {
+ 			wpa_printf(MSG_ERROR,
+ 				   "Line %d: invalid IP address '%s'",
+ 				   line, pos);
+diff --git a/source/hostap-2.10/src/ap/ap_config.h b/source/hostap-2.10/src/ap/ap_config.h
+index 9c98ae0..fa9966c 100644
+--- a/source/hostap-2.10/src/ap/ap_config.h
++++ b/source/hostap-2.10/src/ap/ap_config.h
+@@ -310,7 +310,6 @@ struct hostapd_bss_config {
+ 	char *eap_sim_db;
+ 	unsigned int eap_sim_db_timeout;
+ 	int eap_server_erp; /* Whether ERP is enabled on internal EAP server */
+-	struct hostapd_ip_addr own_ip_addr;
+ 	char *nas_identifier;
+ 	struct hostapd_radius_servers *radius;
+ 	int acct_interim_interval;
+diff --git a/source/hostap-2.10/src/ap/hostapd.c b/source/hostap-2.10/src/ap/hostapd.c
+index 75ba6d0..32365b2 100644
+--- a/source/hostap-2.10/src/ap/hostapd.c
++++ b/source/hostap-2.10/src/ap/hostapd.c
+@@ -777,8 +777,8 @@ static int hostapd_das_nas_mismatch(struct hostapd_data *hapd,
+ 	}
+ 
+ 	if (attr->nas_ip_addr &&
+-	    (hapd->conf->own_ip_addr.af != AF_INET ||
+-	     os_memcmp(&hapd->conf->own_ip_addr.u.v4, attr->nas_ip_addr, 4) !=
++	    (hapd->radius->conf->own_ip_addr.af != AF_INET ||
++	     os_memcmp(&hapd->radius->conf->own_ip_addr.u.v4, attr->nas_ip_addr, 4) !=
+ 	     0)) {
+ 		wpa_printf(MSG_DEBUG, "RADIUS DAS: NAS-IP-Address mismatch");
+ 		return 1;
+@@ -786,8 +786,8 @@ static int hostapd_das_nas_mismatch(struct hostapd_data *hapd,
+ 
+ #ifdef CONFIG_IPV6
+ 	if (attr->nas_ipv6_addr &&
+-	    (hapd->conf->own_ip_addr.af != AF_INET6 ||
+-	     os_memcmp(&hapd->conf->own_ip_addr.u.v6, attr->nas_ipv6_addr, 16)
++	    (hapd->radius->conf->own_ip_addr.af != AF_INET6 ||
++	     os_memcmp(&hapd->radius->conf->own_ip_addr.u.v6, attr->nas_ipv6_addr, 16)
+ 	     != 0)) {
+ 		wpa_printf(MSG_DEBUG, "RADIUS DAS: NAS-IPv6-Address mismatch");
+ 		return 1;
+diff --git a/source/hostap-2.10/src/ap/ieee802_1x.c b/source/hostap-2.10/src/ap/ieee802_1x.c
+index 8fd73a2..6a3cbf3 100644
+--- a/source/hostap-2.10/src/ap/ieee802_1x.c
++++ b/source/hostap-2.10/src/ap/ieee802_1x.c
+@@ -539,9 +539,9 @@ int add_common_radius_attr(struct hostapd_data *hapd,
+ 
+ 	if (!hostapd_config_get_radius_attr(req_attr,
+ 					    RADIUS_ATTR_NAS_IP_ADDRESS) &&
+-	    hapd->conf->own_ip_addr.af == AF_INET &&
++	    hapd->radius->conf->own_ip_addr.af == AF_INET &&
+ 	    !radius_msg_add_attr(msg, RADIUS_ATTR_NAS_IP_ADDRESS,
+-				 (u8 *) &hapd->conf->own_ip_addr.u.v4, 4)) {
++				 (u8 *) &hapd->radius->conf->own_ip_addr.u.v4, 4)) {
+ 		wpa_printf(MSG_ERROR, "Could not add NAS-IP-Address");
+ 		return -1;
+ 	}
+@@ -549,9 +549,9 @@ int add_common_radius_attr(struct hostapd_data *hapd,
+ #ifdef CONFIG_IPV6
+ 	if (!hostapd_config_get_radius_attr(req_attr,
+ 					    RADIUS_ATTR_NAS_IPV6_ADDRESS) &&
+-	    hapd->conf->own_ip_addr.af == AF_INET6 &&
++	    hapd->radius->conf->own_ip_addr.af == AF_INET6 &&
+ 	    !radius_msg_add_attr(msg, RADIUS_ATTR_NAS_IPV6_ADDRESS,
+-				 (u8 *) &hapd->conf->own_ip_addr.u.v6, 16)) {
++				 (u8 *) &hapd->radius->conf->own_ip_addr.u.v6, 16)) {
+ 		wpa_printf(MSG_ERROR, "Could not add NAS-IPv6-Address");
+ 		return -1;
+ 	}
+diff --git a/source/hostap-2.10/src/radius/radius_client.c b/source/hostap-2.10/src/radius/radius_client.c
+index bb730f4..fe56cd9 100644
+--- a/source/hostap-2.10/src/radius/radius_client.c
++++ b/source/hostap-2.10/src/radius/radius_client.c
+@@ -153,102 +153,6 @@ struct radius_msg_list {
+ };
+ 
+ 
+-/**
+- * struct radius_client_data - Internal RADIUS client data
+- *
+- * This data structure is used internally inside the RADIUS client module.
+- * External users allocate this by calling radius_client_init() and free it by
+- * calling radius_client_deinit(). The pointer to this opaque data is used in
+- * calls to other functions as an identifier for the RADIUS client instance.
+- */
+-struct radius_client_data {
+-	/**
+-	 * ctx - Context pointer for hostapd_logger() callbacks
+-	 */
+-	void *ctx;
+-
+-	/**
+-	 * conf - RADIUS client configuration (list of RADIUS servers to use)
+-	 */
+-	struct hostapd_radius_servers *conf;
+-
+-	/**
+-	 * auth_serv_sock - IPv4 socket for RADIUS authentication messages
+-	 */
+-	int auth_serv_sock;
+-
+-	/**
+-	 * acct_serv_sock - IPv4 socket for RADIUS accounting messages
+-	 */
+-	int acct_serv_sock;
+-
+-	/**
+-	 * auth_serv_sock6 - IPv6 socket for RADIUS authentication messages
+-	 */
+-	int auth_serv_sock6;
+-
+-	/**
+-	 * acct_serv_sock6 - IPv6 socket for RADIUS accounting messages
+-	 */
+-	int acct_serv_sock6;
+-
+-	/**
+-	 * auth_sock - Currently used socket for RADIUS authentication server
+-	 */
+-	int auth_sock;
+-
+-	/**
+-	 * acct_sock - Currently used socket for RADIUS accounting server
+-	 */
+-	int acct_sock;
+-
+-	/**
+-	 * auth_handlers - Authentication message handlers
+-	 */
+-	struct radius_rx_handler *auth_handlers;
+-
+-	/**
+-	 * num_auth_handlers - Number of handlers in auth_handlers
+-	 */
+-	size_t num_auth_handlers;
+-
+-	/**
+-	 * acct_handlers - Accounting message handlers
+-	 */
+-	struct radius_rx_handler *acct_handlers;
+-
+-	/**
+-	 * num_acct_handlers - Number of handlers in acct_handlers
+-	 */
+-	size_t num_acct_handlers;
+-
+-	/**
+-	 * msgs - Pending outgoing RADIUS messages
+-	 */
+-	struct radius_msg_list *msgs;
+-
+-	/**
+-	 * num_msgs - Number of pending messages in the msgs list
+-	 */
+-	size_t num_msgs;
+-
+-	/**
+-	 * next_radius_identifier - Next RADIUS message identifier to use
+-	 */
+-	u8 next_radius_identifier;
+-
+-	/**
+-	 * interim_error_cb - Interim accounting error callback
+-	 */
+-	void (*interim_error_cb)(const u8 *addr, void *ctx);
+-
+-	/**
+-	 * interim_error_cb_ctx - interim_error_cb() context data
+-	 */
+-	void *interim_error_cb_ctx;
+-};
+-
+-
+ static int
+ radius_change_server(struct radius_client_data *radius,
+ 		     struct hostapd_radius_server *nserv,
+@@ -1266,6 +1170,8 @@ radius_change_server(struct radius_client_data *radius,
+ 			wpa_printf(MSG_DEBUG, "RADIUS local address: %s:%u",
+ 				   inet_ntoa(claddr.sin_addr),
+ 				   ntohs(claddr.sin_port));
++			radius->conf->own_ip_addr.af = AF_INET;
++			radius->conf->own_ip_addr.u.v4 = claddr.sin_addr;
+ 		}
+ 		break;
+ #ifdef CONFIG_IPV6
+@@ -1277,6 +1183,8 @@ radius_change_server(struct radius_client_data *radius,
+ 				   inet_ntop(AF_INET6, &claddr6.sin6_addr,
+ 					     abuf, sizeof(abuf)),
+ 				   ntohs(claddr6.sin6_port));
++			radius->conf->own_ip_addr.af = AF_INET6;
++			radius->conf->own_ip_addr.u.v6 = claddr6.sin6_addr;
+ 		}
+ 		break;
+ 	}
+diff --git a/source/hostap-2.10/src/radius/radius_client.h b/source/hostap-2.10/src/radius/radius_client.h
+index 679ca3d..18722a8 100644
+--- a/source/hostap-2.10/src/radius/radius_client.h
++++ b/source/hostap-2.10/src/radius/radius_client.h
+@@ -170,6 +170,11 @@ struct hostapd_radius_servers {
+ 	 */
+ 	int msg_dumps;
+ 
++	/**
++     * own_ip_addr - used to store the NAS IP Address and it's IP family
++	 */
++	 struct hostapd_ip_addr own_ip_addr;
++
+ 	/**
+ 	 * client_addr - Client (local) address to use if force_client_addr
+ 	 */
+@@ -242,7 +247,101 @@ typedef enum {
+ 	RADIUS_RX_INVALID_AUTHENTICATOR
+ } RadiusRxResult;
+ 
+-struct radius_client_data;
++/**
++ * struct radius_client_data - Internal RADIUS client data
++ *
++ * This data structure is used internally inside the RADIUS client module.
++ * External users allocate this by calling radius_client_init() and free it by
++ * calling radius_client_deinit(). The pointer to this opaque data is used in
++ * calls to other functions as an identifier for the RADIUS client instance.
++ */
++ struct radius_client_data {
++	/**
++	 * ctx - Context pointer for hostapd_logger() callbacks
++	 */
++	void *ctx;
++
++	/**
++	 * conf - RADIUS client configuration (list of RADIUS servers to use)
++	 */
++	struct hostapd_radius_servers *conf;
++
++	/**
++	 * auth_serv_sock - IPv4 socket for RADIUS authentication messages
++	 */
++	int auth_serv_sock;
++
++	/**
++	 * acct_serv_sock - IPv4 socket for RADIUS accounting messages
++	 */
++	int acct_serv_sock;
++
++	/**
++	 * auth_serv_sock6 - IPv6 socket for RADIUS authentication messages
++	 */
++	int auth_serv_sock6;
++
++	/**
++	 * acct_serv_sock6 - IPv6 socket for RADIUS accounting messages
++	 */
++	int acct_serv_sock6;
++
++	/**
++	 * auth_sock - Currently used socket for RADIUS authentication server
++	 */
++	int auth_sock;
++
++	/**
++	 * acct_sock - Currently used socket for RADIUS accounting server
++	 */
++	int acct_sock;
++
++	/**
++	 * auth_handlers - Authentication message handlers
++	 */
++	struct radius_rx_handler *auth_handlers;
++
++	/**
++	 * num_auth_handlers - Number of handlers in auth_handlers
++	 */
++	size_t num_auth_handlers;
++
++	/**
++	 * acct_handlers - Accounting message handlers
++	 */
++	struct radius_rx_handler *acct_handlers;
++
++	/**
++	 * num_acct_handlers - Number of handlers in acct_handlers
++	 */
++	size_t num_acct_handlers;
++
++	/**
++	 * msgs - Pending outgoing RADIUS messages
++	 */
++	struct radius_msg_list *msgs;
++
++	/**
++	 * num_msgs - Number of pending messages in the msgs list
++	 */
++	size_t num_msgs;
++
++	/**
++	 * next_radius_identifier - Next RADIUS message identifier to use
++	 */
++	u8 next_radius_identifier;
++
++	/**
++	 * interim_error_cb - Interim accounting error callback
++	 */
++	void (*interim_error_cb)(const u8 *addr, void *ctx);
++
++	/**
++	 * interim_error_cb_ctx - interim_error_cb() context data
++	 */
++	void *interim_error_cb_ctx;
++};
++
+ 
+ int radius_client_register(struct radius_client_data *radius,
+ 			   RadiusType msg_type,

--- a/Dynamic_NAS_IP_Update_2_10.patch
+++ b/Dynamic_NAS_IP_Update_2_10.patch
@@ -1,3 +1,8 @@
+##########################################
+From: Srijeyarankesh_JS@comcast.com
+Date: Mar 11, 2025 10:58 AM
+Source: Comcast
+##########################################
 diff --git a/source/hostap-2.10/hostapd/config_file.c b/source/hostap-2.10/hostapd/config_file.c
 index f616e3d..587c022 100644
 --- a/source/hostap-2.10/hostapd/config_file.c

--- a/Dynamic_NAS_IP_Update_2_11.patch
+++ b/Dynamic_NAS_IP_Update_2_11.patch
@@ -1,3 +1,8 @@
+##########################################
+From: Srijeyarankesh_JS@comcast.com
+Date: Mar 11, 2025 10:58 AM
+Source: Comcast
+##########################################
 diff --git a/source/hostap-2.11/hostapd/config_file.c b/source/hostap-2.11/hostapd/config_file.c
 index 3fb0597..1b9b098 100644
 --- a/source/hostap-2.11/hostapd/config_file.c

--- a/Dynamic_NAS_IP_Update_2_11.patch
+++ b/Dynamic_NAS_IP_Update_2_11.patch
@@ -1,0 +1,336 @@
+diff --git a/source/hostap-2.11/hostapd/config_file.c b/source/hostap-2.11/hostapd/config_file.c
+index 3fb0597..1b9b098 100644
+--- a/source/hostap-2.11/hostapd/config_file.c
++++ b/source/hostap-2.11/hostapd/config_file.c
+@@ -2835,7 +2835,7 @@ static int hostapd_config_fill(struct hostapd_config *conf,
+ 		wpa_printf(MSG_INFO, "DEPRECATED: iapp_interface not used");
+ #endif /* CONFIG_IAPP */
+ 	} else if (os_strcmp(buf, "own_ip_addr") == 0) {
+-		if (hostapd_parse_ip_addr(pos, &bss->own_ip_addr)) {
++		if (hostapd_parse_ip_addr(pos, &bss->radius->own_ip_addr)) {
+ 			wpa_printf(MSG_ERROR,
+ 				   "Line %d: invalid IP address '%s'",
+ 				   line, pos);
+diff --git a/source/hostap-2.11/src/ap/ap_config.h b/source/hostap-2.11/src/ap/ap_config.h
+index 150508c..760f3e0 100644
+--- a/source/hostap-2.11/src/ap/ap_config.h
++++ b/source/hostap-2.11/src/ap/ap_config.h
+@@ -311,7 +311,6 @@ struct hostapd_bss_config {
+ 	char *eap_sim_db;
+ 	unsigned int eap_sim_db_timeout;
+ 	int eap_server_erp; /* Whether ERP is enabled on internal EAP server */
+-	struct hostapd_ip_addr own_ip_addr;
+ 	char *nas_identifier;
+ 	struct hostapd_radius_servers *radius;
+ 	int radius_require_message_authenticator;
+diff --git a/source/hostap-2.11/src/ap/hostapd.c b/source/hostap-2.11/src/ap/hostapd.c
+index d6afaeb..58838dd 100644
+--- a/source/hostap-2.11/src/ap/hostapd.c
++++ b/source/hostap-2.11/src/ap/hostapd.c
+@@ -950,8 +950,8 @@ static int hostapd_das_nas_mismatch(struct hostapd_data *hapd,
+ 	}
+ 
+ 	if (attr->nas_ip_addr &&
+-	    (hapd->conf->own_ip_addr.af != AF_INET ||
+-	     os_memcmp(&hapd->conf->own_ip_addr.u.v4, attr->nas_ip_addr, 4) !=
++	    (hapd->radius->conf->own_ip_addr.af != AF_INET ||
++	     os_memcmp(&hapd->radius->conf->own_ip_addr.u.v4, attr->nas_ip_addr, 4) !=
+ 	     0)) {
+ 		wpa_printf(MSG_DEBUG, "RADIUS DAS: NAS-IP-Address mismatch");
+ 		return 1;
+@@ -959,8 +959,8 @@ static int hostapd_das_nas_mismatch(struct hostapd_data *hapd,
+ 
+ #ifdef CONFIG_IPV6
+ 	if (attr->nas_ipv6_addr &&
+-	    (hapd->conf->own_ip_addr.af != AF_INET6 ||
+-	     os_memcmp(&hapd->conf->own_ip_addr.u.v6, attr->nas_ipv6_addr, 16)
++	    (hapd->radius->conf->own_ip_addr.af != AF_INET6 ||
++	     os_memcmp(&hapd->radius->conf->own_ip_addr.u.v6, attr->nas_ipv6_addr, 16)
+ 	     != 0)) {
+ 		wpa_printf(MSG_DEBUG, "RADIUS DAS: NAS-IPv6-Address mismatch");
+ 		return 1;
+diff --git a/source/hostap-2.11/src/ap/ieee802_1x.c b/source/hostap-2.11/src/ap/ieee802_1x.c
+index 8fb3c8f..0204963 100644
+--- a/source/hostap-2.11/src/ap/ieee802_1x.c
++++ b/source/hostap-2.11/src/ap/ieee802_1x.c
+@@ -604,9 +604,9 @@ int add_common_radius_attr(struct hostapd_data *hapd,
+ 
+ 	if (!hostapd_config_get_radius_attr(req_attr,
+ 					    RADIUS_ATTR_NAS_IP_ADDRESS) &&
+-	    hapd->conf->own_ip_addr.af == AF_INET &&
++	    hapd->radius->conf->own_ip_addr.af == AF_INET &&
+ 	    !radius_msg_add_attr(msg, RADIUS_ATTR_NAS_IP_ADDRESS,
+-				 (u8 *) &hapd->conf->own_ip_addr.u.v4, 4)) {
++				 (u8 *) &hapd->radius->conf->own_ip_addr.u.v4, 4)) {
+ 		wpa_printf(MSG_ERROR, "Could not add NAS-IP-Address");
+ 		return -1;
+ 	}
+@@ -614,9 +614,9 @@ int add_common_radius_attr(struct hostapd_data *hapd,
+ #ifdef CONFIG_IPV6
+ 	if (!hostapd_config_get_radius_attr(req_attr,
+ 					    RADIUS_ATTR_NAS_IPV6_ADDRESS) &&
+-	    hapd->conf->own_ip_addr.af == AF_INET6 &&
++	    hapd->radius->conf->own_ip_addr.af == AF_INET6 &&
+ 	    !radius_msg_add_attr(msg, RADIUS_ATTR_NAS_IPV6_ADDRESS,
+-				 (u8 *) &hapd->conf->own_ip_addr.u.v6, 16)) {
++				 (u8 *) &hapd->radius->conf->own_ip_addr.u.v6, 16)) {
+ 		wpa_printf(MSG_ERROR, "Could not add NAS-IPv6-Address");
+ 		return -1;
+ 	}
+diff --git a/source/hostap-2.11/src/radius/radius_client.c b/source/hostap-2.11/src/radius/radius_client.c
+index fbf61fd..0d762b8 100644
+--- a/source/hostap-2.11/src/radius/radius_client.c
++++ b/source/hostap-2.11/src/radius/radius_client.c
+@@ -154,108 +154,6 @@ struct radius_msg_list {
+ };
+ 
+ 
+-/**
+- * struct radius_client_data - Internal RADIUS client data
+- *
+- * This data structure is used internally inside the RADIUS client module.
+- * External users allocate this by calling radius_client_init() and free it by
+- * calling radius_client_deinit(). The pointer to this opaque data is used in
+- * calls to other functions as an identifier for the RADIUS client instance.
+- */
+-struct radius_client_data {
+-	/**
+-	 * ctx - Context pointer for hostapd_logger() callbacks
+-	 */
+-	void *ctx;
+-
+-	/**
+-	 * conf - RADIUS client configuration (list of RADIUS servers to use)
+-	 */
+-	struct hostapd_radius_servers *conf;
+-
+-	/**
+-	 * auth_sock - Currently used socket for RADIUS authentication server
+-	 */
+-	int auth_sock;
+-
+-	/**
+-	 * auth_tls - Whether current authentication connection uses TLS
+-	 */
+-	bool auth_tls;
+-
+-	/**
+-	 * auth_tls_ready - Whether authentication TLS is ready
+-	 */
+-	bool auth_tls_ready;
+-
+-	/**
+-	 * acct_sock - Currently used socket for RADIUS accounting server
+-	 */
+-	int acct_sock;
+-
+-	/**
+-	 * acct_tls - Whether current accounting connection uses TLS
+-	 */
+-	bool acct_tls;
+-
+-	/**
+-	 * acct_tls_ready - Whether accounting TLS is ready
+-	 */
+-	bool acct_tls_ready;
+-
+-	/**
+-	 * auth_handlers - Authentication message handlers
+-	 */
+-	struct radius_rx_handler *auth_handlers;
+-
+-	/**
+-	 * num_auth_handlers - Number of handlers in auth_handlers
+-	 */
+-	size_t num_auth_handlers;
+-
+-	/**
+-	 * acct_handlers - Accounting message handlers
+-	 */
+-	struct radius_rx_handler *acct_handlers;
+-
+-	/**
+-	 * num_acct_handlers - Number of handlers in acct_handlers
+-	 */
+-	size_t num_acct_handlers;
+-
+-	/**
+-	 * msgs - Pending outgoing RADIUS messages
+-	 */
+-	struct radius_msg_list *msgs;
+-
+-	/**
+-	 * num_msgs - Number of pending messages in the msgs list
+-	 */
+-	size_t num_msgs;
+-
+-	/**
+-	 * next_radius_identifier - Next RADIUS message identifier to use
+-	 */
+-	u8 next_radius_identifier;
+-
+-	/**
+-	 * interim_error_cb - Interim accounting error callback
+-	 */
+-	void (*interim_error_cb)(const u8 *addr, void *ctx);
+-
+-	/**
+-	 * interim_error_cb_ctx - interim_error_cb() context data
+-	 */
+-	void *interim_error_cb_ctx;
+-
+-#ifdef CONFIG_RADIUS_TLS
+-	void *tls_ctx;
+-	struct tls_connection *auth_tls_conn;
+-	struct tls_connection *acct_tls_conn;
+-#endif /* CONFIG_RADIUS_TLS */
+-};
+-
+-
+ static int
+ radius_change_server(struct radius_client_data *radius,
+ 		     struct hostapd_radius_server *nserv,
+@@ -1738,6 +1636,8 @@ radius_change_server(struct radius_client_data *radius,
+ 			wpa_printf(MSG_DEBUG, "RADIUS local address: %s:%u",
+ 				   inet_ntoa(claddr.sin_addr),
+ 				   ntohs(claddr.sin_port));
++			radius->conf->own_ip_addr.af = AF_INET;
++			radius->conf->own_ip_addr.u.v4 = claddr.sin_addr;
+ 		}
+ 		break;
+ #ifdef CONFIG_IPV6
+@@ -1749,6 +1649,8 @@ radius_change_server(struct radius_client_data *radius,
+ 				   inet_ntop(AF_INET6, &claddr6.sin6_addr,
+ 					     abuf, sizeof(abuf)),
+ 				   ntohs(claddr6.sin6_port));
++			radius->conf->own_ip_addr.af = AF_INET6;
++			radius->conf->own_ip_addr.u.v6 = claddr6.sin6_addr;
+ 		}
+ 		break;
+ 	}
+diff --git a/source/hostap-2.11/src/radius/radius_client.h b/source/hostap-2.11/src/radius/radius_client.h
+index 03a9800..7611cd3 100644
+--- a/source/hostap-2.11/src/radius/radius_client.h
++++ b/source/hostap-2.11/src/radius/radius_client.h
+@@ -195,6 +195,11 @@ struct hostapd_radius_servers {
+ 	 */
+ 	int msg_dumps;
+ 
++	/**
++     * own_ip_addr - used to store the NAS IP Address and it's IP family
++	 */
++    struct hostapd_ip_addr own_ip_addr;
++
+ 	/**
+ 	 * client_addr - Client (local) address to use if force_client_addr
+ 	 */
+@@ -267,7 +272,108 @@ typedef enum {
+ 	RADIUS_RX_INVALID_AUTHENTICATOR
+ } RadiusRxResult;
+ 
+-struct radius_client_data;
++
++/**
++ * struct radius_client_data - Internal RADIUS client data
++ *
++ * This data structure is used internally inside the RADIUS client module.
++ * External users allocate this by calling radius_client_init() and free it by
++ * calling radius_client_deinit(). The pointer to this opaque data is used in
++ * calls to other functions as an identifier for the RADIUS client instance.
++ */
++ struct radius_client_data {
++	/**
++	 * ctx - Context pointer for hostapd_logger() callbacks
++	 */
++	void *ctx;
++
++	/**
++	 * conf - RADIUS client configuration (list of RADIUS servers to use)
++	 */
++	struct hostapd_radius_servers *conf;
++
++	/**
++	 * auth_sock - Currently used socket for RADIUS authentication server
++	 */
++	int auth_sock;
++
++	/**
++	 * auth_tls - Whether current authentication connection uses TLS
++	 */
++	bool auth_tls;
++
++	/**
++	 * auth_tls_ready - Whether authentication TLS is ready
++	 */
++	bool auth_tls_ready;
++
++	/**
++	 * acct_sock - Currently used socket for RADIUS accounting server
++	 */
++	int acct_sock;
++
++	/**
++	 * acct_tls - Whether current accounting connection uses TLS
++	 */
++	bool acct_tls;
++
++	/**
++	 * acct_tls_ready - Whether accounting TLS is ready
++	 */
++	bool acct_tls_ready;
++
++	/**
++	 * auth_handlers - Authentication message handlers
++	 */
++	struct radius_rx_handler *auth_handlers;
++
++	/**
++	 * num_auth_handlers - Number of handlers in auth_handlers
++	 */
++	size_t num_auth_handlers;
++
++	/**
++	 * acct_handlers - Accounting message handlers
++	 */
++	struct radius_rx_handler *acct_handlers;
++
++	/**
++	 * num_acct_handlers - Number of handlers in acct_handlers
++	 */
++	size_t num_acct_handlers;
++
++	/**
++	 * msgs - Pending outgoing RADIUS messages
++	 */
++	struct radius_msg_list *msgs;
++
++	/**
++	 * num_msgs - Number of pending messages in the msgs list
++	 */
++	size_t num_msgs;
++
++	/**
++	 * next_radius_identifier - Next RADIUS message identifier to use
++	 */
++	u8 next_radius_identifier;
++
++	/**
++	 * interim_error_cb - Interim accounting error callback
++	 */
++	void (*interim_error_cb)(const u8 *addr, void *ctx);
++
++	/**
++	 * interim_error_cb_ctx - interim_error_cb() context data
++	 */
++	void *interim_error_cb_ctx;
++
++#ifdef CONFIG_RADIUS_TLS
++	void *tls_ctx;
++	struct tls_connection *auth_tls_conn;
++	struct tls_connection *acct_tls_conn;
++#endif /* CONFIG_RADIUS_TLS */
++};
++
+ 
+ int radius_client_register(struct radius_client_data *radius,
+ 			   RadiusType msg_type,


### PR DESCRIPTION
Impacted Platforms:
All OneWifi Platforms

Reason for change:We must dynamically update NAS IP to be in accordance with RADIUS IP Family.

Test Procedure: Enable Hotspot VAPs and connect clients. Simultaneously take erouter0 PCAPs. Check if NAS IP is updated properly as per RADIUS IP Family.

Risks: Low

Change-Id: I8f33dc2d45bef2dc10581c88d6b812a49f02dd9d Signed-off-by:Srijeyarankesh_JS@comcast.com